### PR TITLE
style: 버튼 컴포넌트

### DIFF
--- a/src/auth/sign-up.tsx
+++ b/src/auth/sign-up.tsx
@@ -160,7 +160,11 @@ const LabeledInputWithButton = ({
     <label htmlFor={id}>{label}</label>
     <div className="flex w-full gap-2">
       <Input id={id} type={type} placeholder={placeholder} className="flex-1" />
-      <Button label={buttonLabel} variant="primary" onClick={onButtonClick} />
+      <Button
+        label={buttonLabel}
+        variant="secondaryDark"
+        onClick={onButtonClick}
+      />
     </div>
   </div>
 );
@@ -243,8 +247,9 @@ export function Signup() {
           <Button
             key={type.value}
             label={type.label}
-            variant="secondary"
-            isActive={userType === type.value}
+            variant={
+              userType === type.value ? 'secondaryDark' : 'secondaryLight'
+            }
             onClick={() => dispatch(setUserType(type.value))}
             className="flex-1"
           />
@@ -279,7 +284,7 @@ export function Signup() {
                 <Input id="zipcode" value={zipcode} readOnly />
                 <Button
                   label="주소찾기"
-                  variant="primary"
+                  variant="secondaryDark"
                   onClick={openPostcode}
                 />
               </div>
@@ -366,7 +371,10 @@ export function Signup() {
           </div>
         </div>
 
-        <Button label={SUBMIT_BUTTON_LABELS[userType]} variant="primary" />
+        <Button
+          label={SUBMIT_BUTTON_LABELS[userType]}
+          variant="secondaryDark"
+        />
       </div>
     </div>
   );

--- a/src/components/ui/Button.stories.ts
+++ b/src/components/ui/Button.stories.ts
@@ -12,10 +12,9 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {
-    backgroundColor: { control: 'color' },
     variant: {
       control: { type: 'select' },
-      options: ['primary', 'secondary', 'outline'],
+      options: ['primary', 'secondaryLight', 'secondaryDark'],
     },
   },
   args: { onClick: fn() },

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,25 +1,19 @@
 export interface ButtonProps {
-  variant?: 'primary' | 'secondary' | 'outline';
-  backgroundColor?: string;
+  variant?: 'primary' | 'secondaryLight' | 'secondaryDark';
   size?: 'small' | 'medium' | 'large';
   label: string;
   onClick?: () => void;
   className?: string;
-  isActive?: boolean;
 }
 
 export const Button = ({
   variant = 'primary',
   size = 'medium',
-  backgroundColor,
   label,
   onClick,
   className = '',
-  isActive = false,
   ...props
 }: ButtonProps) => {
-  const baseClasses = 'font-semibold transition-colors';
-
   const sizeClasses = {
     small: 'px-3 py-1.5 text-sm',
     medium: 'px-4 py-2 text-base',
@@ -27,18 +21,18 @@ export const Button = ({
   };
 
   const variantClasses = {
-    primary: 'bg-gray-900 text-white rounded-sm',
-    secondary: isActive
-      ? 'bg-gray-900 text-white rounded-sm'
-      : 'bg-white text-gray-900 border border-gray-900 rounded-sm',
-    outline: 'border-gray-900 text-gray-900 rounded-sm',
+    primary:
+      'bg-blue-100 border-blue-100 hover:border-blue-300 text-white rounded active:bg-blue-300 active:border-blue-300 disabled:bg-gray-300 disabled:border-gray-300',
+    secondaryLight:
+      'border-gray-900 hover:bg-gray-100 hover:border-gray-900 text-gray-900 rounded active:bg-gray-200 active:border-gray-900 disabled:bg-white disabled:border-gray-300 disabled:text-gray-300',
+    secondaryDark:
+      'bg-gray-900 border-gray-900 hover:border-gray-900 hover:border-gray-700 text-white rounded active:bg-black active:border-gray-900 disabled:bg-gray-200 disabled:border-gray-200 disabled:text-gray-500',
   };
 
   return (
     <button
       type="button"
-      className={`${baseClasses} ${sizeClasses[size]} ${variantClasses[variant]} ${className}`}
-      style={backgroundColor ? { backgroundColor } : undefined}
+      className={` ${sizeClasses[size]} ${variantClasses[variant]} ${className}`}
       onClick={onClick}
       {...props}
     >


### PR DESCRIPTION
<img width="298" height="186" alt="스크린샷 2025-10-15 오후 3 46 25" src="https://github.com/user-attachments/assets/10c69e64-3d8b-476c-83bf-7dcff99dddf3" />

버튼 컴포넌트 사진과 같이 스타일 수정 했습니다
primary: 기본 버튼
secondaryLight: 보조 버튼 밝은 버전
secondaryDark: 보조버튼 어두운 버전