### PR TITLE
Feature/login - 인증 및 세션 관리 구조 개선

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,8 +4,6 @@ import { RouterProvider } from 'react-router';
 import { useAppDispatch, useAppSelector } from './hooks';
 
 import {
-  setAccessToken,
-  setUser,
   useGetCurrentUserQuery,
   useRefreshTokenOnInitQuery,
 } from '../features/auth';
@@ -26,30 +24,19 @@ export const App = () => {
   const accessToken = useAppSelector((state) => state.auth.accessToken);
   const themeMode = useAppSelector((state) => state.theme.mode);
 
-  const { data: refreshData } = useRefreshTokenOnInitQuery();
+  // 세션 복구
+  const { isLoading: isSessionLoading } = useRefreshTokenOnInitQuery();
+
+  // 유저 정보 조회
+  const { isLoading: isUserLoading } = useGetCurrentUserQuery(undefined, {
+    skip: !accessToken,
+  });
+
   const { data: systemTheme, isSuccess } = useGetSystemThemeQuery();
 
   const { data: userTheme } = useGetUserThemeQuery(undefined, {
     skip: !isAuthenticated,
   });
-
-  const { data: currentUser } = useGetCurrentUserQuery(undefined, {
-    skip: !accessToken,
-  });
-
-  // init
-  useEffect(() => {
-    if (refreshData?.accessToken) {
-      dispatch(setAccessToken(refreshData.accessToken));
-    }
-  }, [refreshData, dispatch]);
-
-  // 유저정보 조회
-  useEffect(() => {
-    if (currentUser) {
-      dispatch(setUser(currentUser));
-    }
-  }, [currentUser, dispatch]);
 
   // 초기 다크모드 적용
   useEffect(() => {
@@ -69,6 +56,17 @@ export const App = () => {
       dispatch(setSystemTheme(systemTheme));
     }
   }, [systemTheme, isSuccess, dispatch]);
+
+  // 세션 복구 또는 유저 정보 로딩 중
+  const isInitializing = isSessionLoading || (!!accessToken && isUserLoading);
+
+  if (isInitializing) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-theme-300 border-t-theme-900" />
+      </div>
+    );
+  }
 
   return <RouterProvider router={router} />;
 };

--- a/src/features/auth/api/auth-api.ts
+++ b/src/features/auth/api/auth-api.ts
@@ -5,6 +5,7 @@ import { createBaseQuery } from '../../../shared/constants';
 
 import { AUTH_ENDPOINTS } from '../constants/auth-constants';
 import type { AuthUser } from '../types/auth-types';
+import { clearAuth, setAccessToken, setUser } from '../slices/auth-slice';
 
 export const authApi = createApi({
   reducerPath: 'authApi',
@@ -16,6 +17,14 @@ export const authApi = createApi({
       query: () => AUTH_ENDPOINTS.GET_CURRENT_USER,
       transformResponse: (response: ApiResponse<AuthUser>) => response.data,
       providesTags: ['Auth'],
+      async onQueryStarted(_, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          dispatch(setUser(data));
+        } catch {
+          dispatch(clearAuth());
+        }
+      },
     }),
 
     // 앱 시작 시 세션 복구
@@ -26,9 +35,18 @@ export const authApi = createApi({
       }),
       transformResponse: (response: ApiResponse<{ accessToken: string }>) =>
         response.data,
+      async onQueryStarted(_, { dispatch, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          dispatch(setAccessToken(data.accessToken));
+        } catch {
+          // 세션 없음 = 비로그인 상태로 조용히 처리
+          dispatch(clearAuth());
+        }
+      },
     }),
 
-    // Access Token 갱신
+    // OAuth 콜백 후 토큰 갱신용
     refreshToken: builder.mutation<{ accessToken: string }, void>({
       query: () => ({
         url: AUTH_ENDPOINTS.REFRESH_TOKEN,
@@ -44,7 +62,6 @@ export const authApi = createApi({
         url: AUTH_ENDPOINTS.LOGOUT,
         method: 'POST',
       }),
-      invalidatesTags: ['Auth'],
     }),
   }),
 });

--- a/src/features/auth/slices/auth-slice.ts
+++ b/src/features/auth/slices/auth-slice.ts
@@ -36,6 +36,7 @@ const authSlice = createSlice({
     clearAuth: (state) => {
       state.accessToken = null;
       state.user = null;
+      state.isAuthenticated = false;
       state.signupRequired = false;
     },
   },

--- a/src/shared/components/layout/header.tsx
+++ b/src/shared/components/layout/header.tsx
@@ -17,12 +17,11 @@ export const Header = () => {
   const user = useSelector((state: RootState) => state.auth.user);
 
   const handleLogout = async () => {
+    dispatch(clearAuth());
     try {
       await logout().unwrap();
     } catch {
       // 서버 에러여도 클라이언트 상태는 초기화
-    } finally {
-      dispatch(clearAuth());
     }
   };
 

--- a/src/shared/constants/api-config.ts
+++ b/src/shared/constants/api-config.ts
@@ -1,18 +1,76 @@
 import { fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 import type { RootState } from '../../app/store';
+import type { ApiResponse } from '../types';
+
+import {
+  setAccessToken,
+  clearAuth,
+} from '../../features/auth/slices/auth-slice';
+import { AUTH_ENDPOINTS } from '../../features/auth/constants/auth-constants';
 
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
-export const createBaseQuery = () =>
-  fetchBaseQuery({
-    baseUrl: API_BASE_URL,
-    credentials: 'include',
-    prepareHeaders: (headers, { getState }) => {
-      const token = (getState() as RootState).auth.accessToken;
-      if (token) {
-        headers.set('Authorization', `Bearer ${token}`);
+const baseQuery = fetchBaseQuery({
+  baseUrl: API_BASE_URL,
+  credentials: 'include',
+  prepareHeaders: (headers, { getState }) => {
+    const token = (getState() as RootState).auth.accessToken;
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+    return headers;
+  },
+});
+
+// 동시에 여러 401이 들어와도 refresh는 한 번만 실행되도록
+let isRefreshing = false;
+
+export const createBaseQuery =
+  () =>
+  async (
+    args: Parameters<typeof baseQuery>[0],
+    api: Parameters<typeof baseQuery>[1],
+    extraOptions: Parameters<typeof baseQuery>[2]
+  ) => {
+    let result = await baseQuery(args, api, extraOptions);
+
+    if (result.error?.status === 401) {
+      // refresh 엔드포인트 자체가 401이면 재시도 없이 clearAuth만
+      const url = typeof args === 'string' ? args : args.url;
+      if (url === AUTH_ENDPOINTS.REFRESH_TOKEN) {
+        api.dispatch(clearAuth());
+        return result;
       }
-      return headers;
-    },
-  });
+
+      if (isRefreshing) {
+        return result;
+      }
+
+      isRefreshing = true;
+
+      try {
+        const refreshResult = await baseQuery(
+          { url: AUTH_ENDPOINTS.REFRESH_TOKEN, method: 'POST' },
+          api,
+          extraOptions
+        );
+
+        if (refreshResult.data) {
+          const { accessToken } = (
+            refreshResult.data as ApiResponse<{ accessToken: string }>
+          ).data;
+
+          api.dispatch(setAccessToken(accessToken));
+          result = await baseQuery(args, api, extraOptions);
+        } else {
+          api.dispatch(clearAuth());
+          alert('로그인이 만료되었습니다. 다시 로그인해주세요.');
+        }
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return result;
+  };

--- a/src/shared/constants/api-config.ts
+++ b/src/shared/constants/api-config.ts
@@ -66,6 +66,7 @@ export const createBaseQuery =
         } else {
           api.dispatch(clearAuth());
           alert('로그인이 만료되었습니다. 다시 로그인해주세요.');
+          window.location.reload();
         }
       } finally {
         isRefreshing = false;


### PR DESCRIPTION
변경 사항

* App.tsx
  - `useRefreshTokenOnInitQuery`, `useGetCurrentUserQuery` 기반 초기화 로직 구현
  - 세션 복구 및 유저 정보 로딩 완료 전까지 스피너 표시
  - 불필요한 `useEffect` 기반 dispatch 제거 (`onQueryStarted`로 대체)

* auth-api.ts
  - `onQueryStarted`를 활용해 API 응답 즉시 Redux dispatch 처리 (타이밍 개선)
  - `useEffect` 타이밍 문제로 인한 세션 복구 실패 이슈 해결

* api-config.ts (createBaseQuery)
  - 401 응답 시 refreshToken으로 accessToken 재발급 후 원래 요청 재시도하는 인터셉터 추가
  - `isRefreshing` 플래그로 동시 다발적 401 발생 시 refresh 중복 호출 방지
  - refreshToken 만료시 `clearAuth` + alert 처리 + window.location.reload(api cache 재설정)

* auth-slice.ts
  - `isAuthenticated` 누락 추가

* header.tsx
  - logout 시 `getCurrentUser` 재실행되는 이슈 invalidatesTags: ['Auth']를 제거하여 해결