### PR TITLE
Feature/story - 매장 운영 정보 등록 및 스토리 등록/리스트 UI

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -19,7 +19,7 @@ import { Signup } from '../features/signup';
 import { CustomerNotice, PartnerNotice } from '../features/notice';
 import { PartnerProfile } from '../features/my-page/pages/partner-profile';
 import { ThemeCustomizer } from '../features/admin/theme';
-import { ShopManagement } from '../features/shop/shop-management/pages/shop-management';
+import { ShopManagement } from '../features/shop/shop-management';
 import { HomePage } from '../pages/home/home-page';
 import { Map } from '../features/map';
 import { MyPage } from '../features/my-page/pages/my-page';

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -9,6 +9,7 @@ import { themeApi } from '../features/admin/theme';
 import { authApi } from '../features/auth';
 import { noticeApi } from '../features/notice';
 import { signupApi } from '../features/signup';
+import { classApi } from '../features/shop/shop-management/api/class-api';
 import { mapApi, oneDayClassApi } from '../features/map';
 import { chatApi } from '../features/chat/api/chat-api';
 
@@ -23,6 +24,7 @@ export const store = configureStore({
     [authApi.reducerPath]: authApi.reducer,
     [noticeApi.reducerPath]: noticeApi.reducer,
     [signupApi.reducerPath]: signupApi.reducer,
+    [classApi.reducerPath]: classApi.reducer,
     [mapApi.reducerPath]: mapApi.reducer,
     [oneDayClassApi.reducerPath]: oneDayClassApi.reducer,
     [chatApi.reducerPath]: chatApi.reducer,
@@ -33,6 +35,7 @@ export const store = configureStore({
       .concat(authApi.middleware)
       .concat(noticeApi.middleware)
       .concat(signupApi.middleware)
+      .concat(classApi.middleware)
       .concat(mapApi.middleware)
       .concat(oneDayClassApi.middleware)
       .concat(chatApi.middleware),

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -10,6 +10,7 @@ import { authApi } from '../features/auth';
 import { noticeApi } from '../features/notice';
 import { signupApi } from '../features/signup';
 import { classApi } from '../features/shop/shop-management/api/class-api';
+import { storyApi } from '../features/shop/shop-management/api/story-api';
 import { mapApi, oneDayClassApi } from '../features/map';
 import { chatApi } from '../features/chat/api/chat-api';
 
@@ -25,6 +26,7 @@ export const store = configureStore({
     [noticeApi.reducerPath]: noticeApi.reducer,
     [signupApi.reducerPath]: signupApi.reducer,
     [classApi.reducerPath]: classApi.reducer,
+    [storyApi.reducerPath]: storyApi.reducer,
     [mapApi.reducerPath]: mapApi.reducer,
     [oneDayClassApi.reducerPath]: oneDayClassApi.reducer,
     [chatApi.reducerPath]: chatApi.reducer,
@@ -36,6 +38,7 @@ export const store = configureStore({
       .concat(noticeApi.middleware)
       .concat(signupApi.middleware)
       .concat(classApi.middleware)
+      .concat(storyApi.middleware)
       .concat(mapApi.middleware)
       .concat(oneDayClassApi.middleware)
       .concat(chatApi.middleware),

--- a/src/features/shop/shop-management/api/story-api.ts
+++ b/src/features/shop/shop-management/api/story-api.ts
@@ -1,0 +1,49 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import { createBaseQuery } from '../../../../shared/constants';
+import { STORY_ENDPOINTS } from '../constants/story-constants';
+
+type DayKey =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+type DayBusinessHours = { openTime: string | null; closeTime: string | null };
+export type UpdateBusinessHoursRequest = Record<DayKey, DayBusinessHours>;
+type ShopBusinessHoursResponse = Record<DayKey, DayBusinessHours>;
+
+export const storyApi = createApi({
+  reducerPath: 'storyApi',
+  baseQuery: createBaseQuery(),
+  tagTypes: ['Story'],
+  endpoints: (builder) => ({
+    getBusinessHours: builder.query<ShopBusinessHoursResponse, void>({
+      query: () => ({
+        url: STORY_ENDPOINTS.BUSINESS_HOURS,
+        method: 'GET',
+      }),
+      transformResponse: (response: { data: ShopBusinessHoursResponse }) =>
+        response.data,
+      providesTags: ['Story'],
+    }),
+    updateBusinessHours: builder.mutation<
+      ShopBusinessHoursResponse,
+      UpdateBusinessHoursRequest
+    >({
+      query: (body) => ({
+        url: STORY_ENDPOINTS.BUSINESS_HOURS,
+        method: 'PATCH',
+        body,
+      }),
+      transformResponse: (response: { data: ShopBusinessHoursResponse }) =>
+        response.data,
+      invalidatesTags: ['Story'],
+    }),
+  }),
+});
+
+export const { useGetBusinessHoursQuery, useUpdateBusinessHoursMutation } =
+  storyApi;

--- a/src/features/shop/shop-management/api/story-api.ts
+++ b/src/features/shop/shop-management/api/story-api.ts
@@ -2,18 +2,10 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 
 import { createBaseQuery } from '../../../../shared/constants';
 import { STORY_ENDPOINTS } from '../constants/story-constants';
-
-type DayKey =
-  | 'monday'
-  | 'tuesday'
-  | 'wednesday'
-  | 'thursday'
-  | 'friday'
-  | 'saturday'
-  | 'sunday';
-type DayBusinessHours = { openTime: string | null; closeTime: string | null };
-export type UpdateBusinessHoursRequest = Record<DayKey, DayBusinessHours>;
-type ShopBusinessHoursResponse = Record<DayKey, DayBusinessHours>;
+import type {
+  ShopBusinessHoursResponse,
+  UpdateBusinessHoursRequest,
+} from '../types/business-hour';
 
 export const storyApi = createApi({
   reducerPath: 'storyApi',

--- a/src/features/shop/shop-management/components/register-business-hour.tsx
+++ b/src/features/shop/shop-management/components/register-business-hour.tsx
@@ -1,0 +1,138 @@
+import { useState, type ChangeEvent } from 'react';
+
+import { Button } from '../../../../shared/components/ui';
+
+type DayKey =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+type DayHours = {
+  openTime: string;
+  closeTime: string;
+};
+
+type BusinessHours = Record<DayKey, DayHours>;
+
+const DAY_LABELS: { key: DayKey; label: string }[] = [
+  { key: 'monday', label: '월' },
+  { key: 'tuesday', label: '화' },
+  { key: 'wednesday', label: '수' },
+  { key: 'thursday', label: '목' },
+  { key: 'friday', label: '금' },
+  { key: 'saturday', label: '토' },
+  { key: 'sunday', label: '일' },
+];
+
+const EMPTY_HOURS: DayHours = { openTime: '', closeTime: '' };
+
+const DEFAULT_BUSINESS_HOURS: BusinessHours = {
+  monday: { ...EMPTY_HOURS },
+  tuesday: { ...EMPTY_HOURS },
+  wednesday: { ...EMPTY_HOURS },
+  thursday: { ...EMPTY_HOURS },
+  friday: { ...EMPTY_HOURS },
+  saturday: { ...EMPTY_HOURS },
+  sunday: { ...EMPTY_HOURS },
+};
+
+export const RegisterBusinessHour = () => {
+  const [selectedDay, setSelectedDay] = useState<DayKey | null>(null);
+  const [businessHours, setBusinessHours] = useState<BusinessHours>(
+    DEFAULT_BUSINESS_HOURS
+  );
+
+  const handleDaySelect = (day: DayKey) => {
+    setSelectedDay(day);
+  };
+
+  const handleTimeChange = (
+    type: keyof DayHours,
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    if (!selectedDay) return;
+    setBusinessHours((prev) => ({
+      ...prev,
+      [selectedDay]: { ...prev[selectedDay], [type]: e.target.value },
+    }));
+  };
+
+  const handleSave = () => {
+    console.log('저장할 운영 정보:', businessHours);
+    alert('운영 정보가 저장되었습니다.');
+  };
+
+  const currentHours = selectedDay ? businessHours[selectedDay] : null;
+
+  return (
+    <section className="flex flex-col rounded-xl bg-white px-[1.5rem] py-4">
+      <div className="flex items-center justify-between border-b pb-3">
+        <h3 className="font-bold">매장 운영 정보</h3>
+        <Button
+          variant="secondaryDark"
+          className="flex items-center justify-center px-4 py-2 text-xs"
+          label="저장"
+          onClick={handleSave}
+        />
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-end gap-8">
+        {/* 운영 요일 */}
+        <div className="flex flex-col gap-3">
+          <p className="text-sm font-medium">운영요일</p>
+          <div className="flex gap-2">
+            {DAY_LABELS.map(({ key, label }) => (
+              <button
+                key={key}
+                className={`flex h-10 w-10 items-center justify-center rounded-md bg-theme-200 text-sm transition-colors ${
+                  selectedDay === key
+                    ? 'border-2 border-gray-800 font-semibold'
+                    : 'border border-gray-300 text-theme-500 hover:border-gray-500'
+                }`}
+                onClick={() => handleDaySelect(key)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 운영 시간 */}
+        <div className="flex flex-col gap-3">
+          <p className="text-sm font-medium">운영시간</p>
+          {selectedDay === null ? (
+            <p className="h-10 text-xs text-gray-500">
+              요일을 먼저 선택해주세요.
+            </p>
+          ) : (
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                placeholder="HH:MM"
+                maxLength={5}
+                className="h-10 w-[5.8rem] rounded-lg border border-gray-300 px-2 py-1.5 text-center text-sm disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-300"
+                disabled={selectedDay === null}
+                value={currentHours?.openTime ?? ''}
+                onChange={(e) => handleTimeChange('openTime', e)}
+              />
+              <span>&sim;</span>
+              <input
+                type="text"
+                placeholder="HH:MM"
+                maxLength={5}
+                className="h-10 w-[5.8rem] rounded-lg border border-gray-300 px-2 py-1.5 text-center text-sm disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-300"
+                disabled={selectedDay === null}
+                value={currentHours?.closeTime ?? ''}
+                onChange={(e) => handleTimeChange('closeTime', e)}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/features/shop/shop-management/components/register-business-hour.tsx
+++ b/src/features/shop/shop-management/components/register-business-hour.tsx
@@ -1,6 +1,10 @@
-import { useState, type ChangeEvent } from 'react';
+import { useState, useEffect, type ChangeEvent, useRef } from 'react';
 
 import { Button } from '../../../../shared/components/ui';
+import {
+  useGetBusinessHoursQuery,
+  useUpdateBusinessHoursMutation,
+} from '../api/story-api';
 
 type DayKey =
   | 'monday'
@@ -14,21 +18,22 @@ type DayKey =
 type DayHours = {
   openTime: string;
   closeTime: string;
+  isDayOff: boolean;
 };
 
 type BusinessHours = Record<DayKey, DayHours>;
 
-const DAY_LABELS: { key: DayKey; label: string }[] = [
-  { key: 'monday', label: '월' },
-  { key: 'tuesday', label: '화' },
-  { key: 'wednesday', label: '수' },
-  { key: 'thursday', label: '목' },
-  { key: 'friday', label: '금' },
-  { key: 'saturday', label: '토' },
-  { key: 'sunday', label: '일' },
+const DAY_LABELS: { key: DayKey; label: string; full: string }[] = [
+  { key: 'monday', label: '월', full: '월요일' },
+  { key: 'tuesday', label: '화', full: '화요일' },
+  { key: 'wednesday', label: '수', full: '수요일' },
+  { key: 'thursday', label: '목', full: '목요일' },
+  { key: 'friday', label: '금', full: '금요일' },
+  { key: 'saturday', label: '토', full: '토요일' },
+  { key: 'sunday', label: '일', full: '일요일' },
 ];
 
-const EMPTY_HOURS: DayHours = { openTime: '', closeTime: '' };
+const EMPTY_HOURS: DayHours = { openTime: '', closeTime: '', isDayOff: false };
 
 const DEFAULT_BUSINESS_HOURS: BusinessHours = {
   monday: { ...EMPTY_HOURS },
@@ -45,13 +50,54 @@ export const RegisterBusinessHour = () => {
   const [businessHours, setBusinessHours] = useState<BusinessHours>(
     DEFAULT_BUSINESS_HOURS
   );
+  const [isPreviewVisible, setIsPreviewVisible] = useState(false);
+  const previewRef = useRef<HTMLDivElement>(null);
+
+  const { data: businessHoursData } = useGetBusinessHoursQuery();
+  const [updateBusinessHours, { isLoading }] = useUpdateBusinessHoursMutation();
+
+  useEffect(() => {
+    if (!businessHoursData) return;
+    const toHours = (day: {
+      openTime: string | null;
+      closeTime: string | null;
+    }): DayHours => ({
+      openTime: day.openTime ?? '',
+      closeTime: day.closeTime ?? '',
+      isDayOff: day.openTime === null && day.closeTime === null,
+    });
+    setBusinessHours({
+      monday: toHours(businessHoursData.monday),
+      tuesday: toHours(businessHoursData.tuesday),
+      wednesday: toHours(businessHoursData.wednesday),
+      thursday: toHours(businessHoursData.thursday),
+      friday: toHours(businessHoursData.friday),
+      saturday: toHours(businessHoursData.saturday),
+      sunday: toHours(businessHoursData.sunday),
+    });
+  }, [businessHoursData]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        previewRef.current &&
+        !previewRef.current.contains(e.target as Node)
+      ) {
+        setIsPreviewVisible(false);
+      }
+    };
+    if (isPreviewVisible) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isPreviewVisible]);
 
   const handleDaySelect = (day: DayKey) => {
     setSelectedDay(day);
   };
 
   const handleTimeChange = (
-    type: keyof DayHours,
+    type: 'openTime' | 'closeTime',
     e: ChangeEvent<HTMLInputElement>
   ) => {
     if (!selectedDay) return;
@@ -61,9 +107,35 @@ export const RegisterBusinessHour = () => {
     }));
   };
 
-  const handleSave = () => {
-    console.log('저장할 운영 정보:', businessHours);
-    alert('운영 정보가 저장되었습니다.');
+  const handleDayOffChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!selectedDay) return;
+    const isDayOff = e.target.checked;
+    setBusinessHours((prev) => ({
+      ...prev,
+      [selectedDay]: {
+        ...prev[selectedDay],
+        isDayOff,
+      },
+    }));
+  };
+
+  const handleSave = async () => {
+    const requestBody = Object.fromEntries(
+      Object.entries(businessHours).map(([day, hours]) => [
+        day,
+        {
+          openTime: hours.isDayOff ? null : hours.openTime.trim() || null,
+          closeTime: hours.isDayOff ? null : hours.closeTime.trim() || null,
+        },
+      ])
+    ) as Record<DayKey, { openTime: string | null; closeTime: string | null }>;
+
+    try {
+      await updateBusinessHours(requestBody).unwrap();
+      alert('운영 정보가 저장되었습니다.');
+    } catch {
+      alert('운영 정보 저장에 실패했습니다. 다시 시도해주세요.');
+    }
   };
 
   const currentHours = selectedDay ? businessHours[selectedDay] : null;
@@ -72,17 +144,46 @@ export const RegisterBusinessHour = () => {
     <section className="flex flex-col rounded-xl bg-white px-[1.5rem] py-4">
       <div className="flex items-center justify-between border-b pb-3">
         <h3 className="font-bold">매장 운영 정보</h3>
-        <Button
-          variant="secondaryDark"
-          className="flex items-center justify-center px-4 py-2 text-xs"
-          label="저장"
-          onClick={handleSave}
-        />
+        <div className="relative flex gap-1" ref={previewRef}>
+          <Button
+            variant="secondaryLight"
+            className="flex items-center justify-center px-4 py-2 text-xs disabled:cursor-not-allowed disabled:opacity-40"
+            label={isLoading ? '로딩 중...' : '확인'}
+            disabled={isLoading}
+            onClick={() => setIsPreviewVisible((prev) => !prev)}
+          />
+
+          {/* 운영시간 미리보기 모달 */}
+          {isPreviewVisible && (
+            <div className="absolute -right-40 -top-8 z-10 flex flex-col gap-2 rounded-lg border border-gray-200 bg-theme-100 p-3 shadow-md">
+              {DAY_LABELS.map(({ key, full }) => {
+                const hours = businessHours[key];
+                const timeText =
+                  hours.isDayOff || (!hours.openTime && !hours.closeTime)
+                    ? '휴무'
+                    : `${hours.openTime} ~ ${hours.closeTime}`;
+                return (
+                  <div key={key} className="flex text-xs text-gray-700">
+                    <span className="w-[3.1rem] shrink-0">{full} :</span>
+                    <span className="w-[4.7rem]">{timeText}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          <Button
+            variant="secondaryDark"
+            className="flex items-center justify-center px-4 py-2 text-xs disabled:cursor-not-allowed disabled:opacity-40"
+            label={isLoading ? '저장 중...' : '저장'}
+            disabled={isLoading}
+            onClick={handleSave}
+          />
+        </div>
       </div>
 
       <div className="mt-3 flex flex-wrap items-end gap-8">
         {/* 운영 요일 */}
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-6">
           <p className="text-sm font-medium">운영요일</p>
           <div className="flex gap-2">
             {DAY_LABELS.map(({ key, label }) => (
@@ -102,7 +203,7 @@ export const RegisterBusinessHour = () => {
         </div>
 
         {/* 운영 시간 */}
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-6">
           <p className="text-sm font-medium">운영시간</p>
           {selectedDay === null ? (
             <p className="h-10 text-xs text-gray-500">
@@ -114,8 +215,8 @@ export const RegisterBusinessHour = () => {
                 type="text"
                 placeholder="HH:MM"
                 maxLength={5}
-                className="h-10 w-[5.8rem] rounded-lg border border-gray-300 px-2 py-1.5 text-center text-sm disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-300"
-                disabled={selectedDay === null}
+                className="h-10 w-[5.8rem] rounded-lg border border-gray-300 px-2 py-1.5 text-center text-sm disabled:cursor-not-allowed disabled:bg-theme-200 disabled:text-gray-300"
+                disabled={selectedDay === null || !!currentHours?.isDayOff}
                 value={currentHours?.openTime ?? ''}
                 onChange={(e) => handleTimeChange('openTime', e)}
               />
@@ -124,11 +225,21 @@ export const RegisterBusinessHour = () => {
                 type="text"
                 placeholder="HH:MM"
                 maxLength={5}
-                className="h-10 w-[5.8rem] rounded-lg border border-gray-300 px-2 py-1.5 text-center text-sm disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-300"
-                disabled={selectedDay === null}
+                className="h-10 w-[5.8rem] rounded-lg border border-gray-300 px-2 py-1.5 text-center text-sm disabled:cursor-not-allowed disabled:bg-theme-200 disabled:text-gray-300"
+                disabled={selectedDay === null || !!currentHours?.isDayOff}
                 value={currentHours?.closeTime ?? ''}
                 onChange={(e) => handleTimeChange('closeTime', e)}
               />
+              {/* 휴무 체크박스 */}
+              <label className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-500">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 cursor-pointer accent-gray-800"
+                  checked={currentHours?.isDayOff ?? false}
+                  onChange={handleDayOffChange}
+                />
+                휴무
+              </label>
             </div>
           )}
         </div>

--- a/src/features/shop/shop-management/components/register-business-hour.tsx
+++ b/src/features/shop/shop-management/components/register-business-hour.tsx
@@ -5,23 +5,7 @@ import {
   useGetBusinessHoursQuery,
   useUpdateBusinessHoursMutation,
 } from '../api/story-api';
-
-type DayKey =
-  | 'monday'
-  | 'tuesday'
-  | 'wednesday'
-  | 'thursday'
-  | 'friday'
-  | 'saturday'
-  | 'sunday';
-
-type DayHours = {
-  openTime: string;
-  closeTime: string;
-  isDayOff: boolean;
-};
-
-type BusinessHours = Record<DayKey, DayHours>;
+import type { BusinessHours, DayHours, DayKey } from '../types/business-hour';
 
 const DAY_LABELS: { key: DayKey; label: string; full: string }[] = [
   { key: 'monday', label: '월', full: '월요일' },

--- a/src/features/shop/shop-management/components/story-management.tsx
+++ b/src/features/shop/shop-management/components/story-management.tsx
@@ -1,0 +1,315 @@
+import { useState, useRef, type ChangeEvent } from 'react';
+import { ImagePlus, X, ArrowUp, ArrowDown } from 'lucide-react';
+
+import { Button } from '../../../../shared/components/ui';
+import { Input } from '../../../../shared/components/ui';
+
+type StoryMode = 'registering' | 'editing';
+
+type Story = {
+  id: number;
+  imageUrl: string;
+  title: string;
+  content: string;
+  createdAt: string;
+};
+
+// TODO: API 연결 시 제거
+let nextStoryId = 5;
+
+// TODO: API 연결 시 제거
+const DUMMY_STORIES: Story[] = [
+  {
+    id: 1,
+    imageUrl: 'https://placehold.co/40x40/c8d4e0/c8d4e0',
+    title: '수원은 비가 온대요, 대구는 쨍쨍합니다',
+    content:
+      "오늘은 '수니작가'님 신상 굿즈 들어오는 날~ 비 오기 전에 얼른 도착해주세요",
+    createdAt: '2025.09.13',
+  },
+  {
+    id: 2,
+    imageUrl: 'https://placehold.co/40x40/d4c8e0/d4c8e0',
+    title: '제목 어쩌구 저쩌구 말라말라 라',
+    content: '내용 어쩌구 저쩌구 길고 긴 이야기가 계속됩니다 정말로요',
+    createdAt: '2025.09.12',
+  },
+  {
+    id: 3,
+    imageUrl: 'https://placehold.co/40x40/c8e0d4/c8e0d4',
+    title: '제목 어쩌구 저쩌구 말라말라 라',
+    content: '내용 어쩌구 저쩌구...',
+    createdAt: '2025.09.11',
+  },
+  {
+    id: 4,
+    imageUrl: 'https://placehold.co/40x40/e0d4c8/e0d4c8',
+    title: '제목 어쩌구 저쩌구 말라말라 라라',
+    content: '내용 어쩌구 저쩌구 여기도 내용이 좀 길어요 한번 봐요',
+    createdAt: '2025.09.10',
+  },
+  {
+    id: 5,
+    imageUrl: 'https://placehold.co/40x40/e0c8d4/e0c8d4',
+    title: '더미 스토리 5번째 항목입니다',
+    content: '스크롤 테스트용 항목이에요',
+    createdAt: '2025.09.09',
+  },
+  {
+    id: 6,
+    imageUrl: 'https://placehold.co/40x40/d4e0c8/d4e0c8',
+    title: '더미 스토리 6번째 항목입니다',
+    content: '스크롤 테스트용 항목이에요',
+    createdAt: '2025.09.08',
+  },
+];
+
+const LIST_HEIGHT = '15rem';
+
+export const StoryManage = () => {
+  const [mode, setMode] = useState<StoryMode>('registering');
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const [image, setImage] = useState<string | null>(null);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const [stories, setStories] = useState<Story[]>(DUMMY_STORIES);
+  const [sortAsc, setSortAsc] = useState(false);
+
+  // TODO: API 연결 시 활용 (intersection observer 타깃)
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isActionEnabled =
+    image !== null && title.trim() !== '' && content.trim() !== '';
+
+  const resetForm = () => {
+    setImage(null);
+    setTitle('');
+    setContent('');
+    setEditingId(null);
+    setMode('registering');
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleImageAdd = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImage(URL.createObjectURL(file));
+  };
+
+  const handleImageRemove = () => {
+    setImage(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleUpload = () => {
+    if (!isActionEnabled) return;
+    const newStory: Story = {
+      id: nextStoryId++,
+      imageUrl: image!,
+      title,
+      content,
+      createdAt: new Date().toISOString().slice(0, 10).replace(/-/g, '.'),
+    };
+    setStories((prev) => [newStory, ...prev]);
+    resetForm();
+  };
+
+  const handleEditClick = (story: Story) => {
+    const confirmed = window.confirm('해당 스토리를 수정하시겠습니까?');
+    if (!confirmed) return;
+    setMode('editing');
+    setEditingId(story.id);
+    setImage(story.imageUrl);
+    setTitle(story.title);
+    setContent(story.content);
+  };
+
+  const handleEditSave = () => {
+    if (!isActionEnabled || editingId === null) return;
+    setStories((prev) =>
+      prev.map((s) =>
+        s.id === editingId ? { ...s, imageUrl: image!, title, content } : s
+      )
+    );
+    resetForm();
+  };
+
+  const handleDeleteClick = (story: Story) => {
+    const confirmed = window.confirm(
+      `제목: ${story.title}\n내용: ${story.content}\n\n위 스토리를 삭제하시겠습니까?`
+    );
+    if (confirmed) {
+      setStories((prev) => prev.filter((s) => s.id !== story.id));
+    }
+  };
+
+  const sortedStories = [...stories].sort((a, b) => {
+    const cmp = a.createdAt.localeCompare(b.createdAt);
+    return sortAsc ? cmp : -cmp;
+  });
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* 스토리 등록/수정 */}
+      <section className="flex flex-col rounded-xl bg-white px-[1.5rem] pb-[0.75rem] pt-[1.5rem]">
+        <div className="flex items-center justify-between border-b pb-3">
+          <h3 className="font-bold">
+            {mode === 'editing' ? '스토리 수정하기' : '스토리 등록하기'}
+          </h3>
+        </div>
+
+        <div className="mt-3 flex flex-col gap-3">
+          <div className="relative h-[6rem] w-[6rem]">
+            {image ? (
+              <>
+                <img
+                  src={image}
+                  alt="story-preview"
+                  className="h-full w-full rounded-lg bg-gray-200 object-cover"
+                />
+                <button
+                  className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow"
+                  onClick={handleImageRemove}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </>
+            ) : (
+              <label className="flex h-full w-full cursor-pointer items-center justify-center rounded-lg bg-gray-200">
+                <ImagePlus className="h-5 w-5" />
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpg,image/jpeg,image/png"
+                  className="hidden"
+                  onChange={handleImageAdd}
+                />
+              </label>
+            )}
+          </div>
+
+          <Input
+            className="w-full"
+            placeholder="제목을 입력해주세요"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+
+          <textarea
+            className="block h-[7.0625rem] w-full resize-none rounded-lg border border-gray-500 px-3 py-2 text-sm placeholder:text-gray-400"
+            placeholder="내용을 입력해주세요"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+
+          <div className="flex justify-center gap-1">
+            {mode === 'editing' && (
+              <Button
+                variant="secondaryDark"
+                className="flex items-center justify-center px-4 py-2 text-xs"
+                label="취소"
+                onClick={resetForm}
+              />
+            )}
+            <Button
+              variant="secondaryDark"
+              className="flex items-center justify-center px-4 py-2 text-xs disabled:cursor-not-allowed disabled:opacity-40"
+              label={mode === 'editing' ? '수정완료' : '업로드'}
+              disabled={!isActionEnabled}
+              onClick={mode === 'editing' ? handleEditSave : handleUpload}
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* 스토리 리스트 */}
+      <section className="flex flex-col rounded-xl bg-white px-[1.5rem] py-4">
+        <div className="flex items-center justify-between border-b pb-3">
+          <h3 className="font-bold">스토리 리스트</h3>
+        </div>
+
+        <div className="flex items-center border-b py-3 text-sm text-theme-900">
+          <div className="w-14 shrink-0 text-center">썸네일</div>
+          <div className="w-[10rem] shrink-0 text-center">제목</div>
+          <div className="min-w-0 flex-1 text-center">내용</div>
+          <div className="flex w-[5rem] shrink-0 justify-center">
+            <button
+              className="flex items-center gap-1"
+              onClick={() => setSortAsc((prev) => !prev)}
+            >
+              작성일
+              {sortAsc ? (
+                <ArrowUp className="h-3 w-3" />
+              ) : (
+                <ArrowDown className="h-3 w-3" />
+              )}
+            </button>
+          </div>
+          <div className="ml-2 w-[5.5rem] shrink-0 text-center">
+            수정 / 삭제
+          </div>
+        </div>
+
+        {sortedStories.length === 0 ? (
+          <div
+            className="overflow-y-auto bg-red-300"
+            style={{ height: LIST_HEIGHT }}
+          >
+            <p className="py-6 text-center text-xs text-gray-400">
+              등록된 스토리가 없습니다.
+            </p>
+          </div>
+        ) : (
+          <ul className="overflow-y-auto" style={{ height: LIST_HEIGHT }}>
+            {sortedStories.map((story) => (
+              <li key={story.id} className="flex items-center py-3 text-sm">
+                <div className="flex w-14 shrink-0 justify-center">
+                  <img
+                    src={story.imageUrl}
+                    alt="thumbnail"
+                    className="h-10 w-10 rounded bg-gray-200 object-cover"
+                  />
+                </div>
+
+                <div className="w-[10rem] shrink-0 overflow-hidden px-3 text-left">
+                  <p className="truncate">{story.title}</p>
+                </div>
+
+                <div className="min-w-0 flex-1 overflow-hidden px-3 text-left">
+                  <p className="truncate text-gray-500">{story.content}</p>
+                </div>
+
+                <div className="w-[5rem] shrink-0 text-center text-gray-500">
+                  {story.createdAt}
+                </div>
+
+                <div className="ml-2 w-[5rem] shrink-0">
+                  <div className="flex justify-center gap-1">
+                    <button
+                      className="flex items-center justify-center rounded bg-blue-400 px-1.5 py-1.5 text-xs text-white hover:bg-blue-300"
+                      onClick={() => handleEditClick(story)}
+                    >
+                      수정
+                    </button>
+                    <button
+                      className="flex items-center justify-center rounded bg-black px-1.5 py-1.5 text-xs text-white hover:bg-gray-700"
+                      onClick={() => handleDeleteClick(story)}
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </div>
+              </li>
+            ))}
+
+            {/* TODO: API 연결 시 intersection observer 타깃으로 사용 */}
+            <div ref={bottomRef} />
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/src/features/shop/shop-management/constants/story-constants.ts
+++ b/src/features/shop/shop-management/constants/story-constants.ts
@@ -1,0 +1,3 @@
+export const STORY_ENDPOINTS = {
+  BUSINESS_HOURS: '/api/v1/shops/me/business-hours',
+} as const;

--- a/src/features/shop/shop-management/index.ts
+++ b/src/features/shop/shop-management/index.ts
@@ -1,0 +1,4 @@
+export { ShopManagement } from '../shop-management/pages/shop-management';
+
+export { classApi } from '../shop-management/api/class-api';
+export { storyApi } from '../shop-management/api/story-api';

--- a/src/features/shop/shop-management/pages/shop-management.tsx
+++ b/src/features/shop/shop-management/pages/shop-management.tsx
@@ -14,6 +14,9 @@ import {
   useDeleteClassMutation,
 } from '../api/class-api';
 
+import { StoryManage } from '../components/story-management';
+import { RegisterBusinessHour } from '../components/register-business-hour';
+
 type Mode = 'default' | 'registering' | 'selected' | 'editing';
 
 export const ShopManagement = () => {
@@ -185,6 +188,12 @@ export const ShopManagement = () => {
           <h2>관리 홈 / 나의 소품샵 관리</h2>
         </header>
         <main className="grid w-full flex-1 grid-cols-2 gap-3 overflow-y-auto bg-gray-100 p-5 px-[3.625rem]">
+          {/* 클래스 등록 및 매장 운영 정보 등록 */}
+          <div className="flex flex-col gap-3">
+            <StoryManage />
+            <RegisterBusinessHour />
+          </div>
+
           {/* 클래스 등록하기 */}
           <div className="flex h-full flex-col gap-3">
             <section className="flex flex-col rounded-xl bg-white px-[3.125rem] pb-[1.6875rem] pt-4">

--- a/src/features/shop/shop-management/types/business-hour.ts
+++ b/src/features/shop/shop-management/types/business-hour.ts
@@ -1,0 +1,25 @@
+export type DayKey =
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday'
+  | 'sunday';
+
+export type DayHours = {
+  openTime: string;
+  closeTime: string;
+  isDayOff: boolean;
+};
+
+export type BusinessHours = Record<DayKey, DayHours>;
+
+type DayBusinessHours = {
+  openTime: string | null;
+  closeTime: string | null;
+};
+
+export type UpdateBusinessHoursRequest = Record<DayKey, DayBusinessHours>;
+
+export type ShopBusinessHoursResponse = Record<DayKey, DayBusinessHours>;


### PR DESCRIPTION
* 매장 운영 정보
  - 운영요일 선택 > 운영시간 등록 > 저장 순으로 진행
  - 운영요일 선택시 운영시간 등록 란에 등록된 정보를 불러옴 (`/api/v1/shops/me/business-hours`) - GET
  - 운영시간을 입력하지 않거나 휴무 버튼을 체크하여 `휴무` 설정 가능
  - 운영시간을 `HH:MM` ~ `HH:MM` 방식으로 입력하고 저장버튼 클릭하여 저장 및 수정 (`/api/v1/shops/me/business-hours`) - PATCH
  - 저장된 정보는 확인 버튼을 클릭하여 바로 확인이 가능하고, 지도 페이지에서 소품샵을 클릭하여 상세정보에서도 확인가능.
  - 확인버튼을 클릭하여 모달을 열고, 확인버튼 또는 모달을 제외한 곳을 클릭하여 닫을 수 있음.

* 스토리 등록하기, 스토리 리스트
  - 현재 UI 작업이 완료된 상태이며 더미 데이터로 작업됨