### PR TITLE
Feature/partner layout

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -117,7 +117,7 @@ export const router = createBrowserRouter([
                 element: <div>작가 재고 관리</div>,
               },
               { path: ROUTES.ARTIST_SHOPS, element: <div>소품샵 목록</div> },
-              { path: ROUTES.ARTIST_SHIPMENTS, element: <div>배송 관리</div> },
+              { path: ROUTES.ARTIST_SHIPMENTS, element: <div>출고 관리</div> },
               { path: ROUTES.ARTIST_SETTLEMENTS, element: <div>정산</div> },
               {
                 path: ROUTES.ARTIST_SETTLEMENTS_HISTORY,

--- a/src/features/artist/setting/pages/artist-setting-page.tsx
+++ b/src/features/artist/setting/pages/artist-setting-page.tsx
@@ -1,27 +1,16 @@
-import { Aside } from '../../../../shared/components/layout';
-
 import { ToggleSwitch } from '../../../../shared/components/ui/toggleswitch';
 
 export const ArtistSettingPage = () => {
   return (
-    <div className="flex h-screen w-screen bg-gray-100">
-      <Aside />
-      <div className="flex flex-1 flex-col">
-        <header className="h-[4.5rem] w-full bg-white p-6 text-black">
-          <h2>환경 설정</h2>
-        </header>
-
-        <main className="ml-[3.25rem] mt-5 flex h-[20.5625rem] w-[42.5625rem] flex-col gap-4 rounded-2xl bg-white pb-[3.125rem] pl-[3.9375rem] pr-[5.3125rem] pt-[2.1875rem]">
-          <h3 className="text-xl">알림 설정</h3>
-          <div className="flex h-full w-full flex-col gap-[0.625rem] rounded-md bg-gray-200 px-[1.1875rem] pt-[1.625rem]">
-            <ToggleSwitch id="" label="정산알림 on/off" />
-            <ToggleSwitch id="" label="세금계산서 요청 알림" />
-            <ToggleSwitch id="" label="입점 제의 알림" />
-            <ToggleSwitch id="" label="카카오톡 알림톡 수신동의" />
-            <ToggleSwitch id="" label="E-mail 수신 동의" />
-          </div>
-        </main>
+    <section className="flex h-[20.5625rem] w-[42.5625rem] flex-col gap-4 rounded-2xl bg-white pb-[3.125rem] pl-[3.9375rem] pr-[5.3125rem] pt-[2.1875rem]">
+      <h3 className="text-xl">알림 설정</h3>
+      <div className="flex h-full w-full flex-col gap-[0.625rem] rounded-md bg-gray-200 px-[1.1875rem] pt-[1.625rem]">
+        <ToggleSwitch id="" label="정산알림 on/off" />
+        <ToggleSwitch id="" label="세금계산서 요청 알림" />
+        <ToggleSwitch id="" label="입점 제의 알림" />
+        <ToggleSwitch id="" label="카카오톡 알림톡 수신동의" />
+        <ToggleSwitch id="" label="E-mail 수신 동의" />
       </div>
-    </div>
+    </section>
   );
 };

--- a/src/features/chat/components/chat-list.tsx
+++ b/src/features/chat/components/chat-list.tsx
@@ -95,7 +95,7 @@ export const ChatList = () => {
   );
 
   return (
-    <div className="flex h-full flex-col bg-white">
+    <div className="flex h-full flex-col rounded-xl bg-white">
       <div className="border-b border-theme-200 p-4">
         {/* 새 메세지 버튼 */}
         <button

--- a/src/features/chat/components/chat-room.tsx
+++ b/src/features/chat/components/chat-room.tsx
@@ -111,7 +111,7 @@ export const ChatRoom = () => {
   ]);
 
   return (
-    <div className="flex h-full flex-col bg-white">
+    <div className="flex h-full flex-col rounded-xl bg-white">
       <ChatHeader />
       <MessageList />
       <MessageInput />

--- a/src/features/chat/components/message-input.tsx
+++ b/src/features/chat/components/message-input.tsx
@@ -151,7 +151,7 @@ export const MessageInput = () => {
   if (!selectedChatRoomId) return null;
 
   return (
-    <div className="border-t border-theme-200 bg-white px-6 py-4">
+    <div className="rounded-b-xl border-t border-theme-200 bg-white px-6 py-4">
       <div className="flex items-center gap-3">
         <button
           onClick={handleFileAttach}

--- a/src/features/chat/components/user-select-modal.tsx
+++ b/src/features/chat/components/user-select-modal.tsx
@@ -107,7 +107,7 @@ export const UserSelectModal = ({ onClose }: UserSelectModalProps) => {
         </div>
 
         {/* 테이블 헤더 */}
-        <div className="mb-2 grid grid-cols-3 border-b border-gray-200 pb-2">
+        <div className="grid grid-cols-3 border-b border-gray-200 pb-4 text-center">
           <span className="text-sm font-semibold text-gray-900">계정명</span>
           <span className="text-sm font-semibold text-gray-900">
             주요 카테고리

--- a/src/features/chat/pages/chat.tsx
+++ b/src/features/chat/pages/chat.tsx
@@ -1,5 +1,4 @@
 import { useAppSelector } from '../../../app/hooks';
-import { Aside } from '../../../shared/components/layout';
 
 import { ChatWebSocketProvider } from '../hooks/chat-websocket-provider';
 import { useChatWebSocketContext } from '../hooks/use-chat-websocket-context';
@@ -13,42 +12,17 @@ const ChatPageInner = () => {
   const { isConnected } = useChatWebSocketContext();
 
   return (
-    <div className="flex h-screen">
-      <Aside />
-
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="px-[3.375rem] py-6">
-          <nav aria-label="breadcrumb">
-            <ol className="flex items-center text-lg">
-              <li>
-                <a className="font-medium text-neutral-900" href="/dashboard">
-                  마이페이지
-                </a>
-              </li>
-              <li
-                className="font-bold text-neutral-900 before:mx-2 before:content-['/']"
-                aria-current="page"
-              >
-                메세지
-              </li>
-            </ol>
-          </nav>
-          <h1 className="sr-only">메세지</h1>
-        </header>
-
-        <div className="flex flex-1 overflow-hidden">
-          <div className="flex w-96 flex-col border-r border-gray-200">
-            {isConnected ? (
-              <ChatList />
-            ) : (
-              <p>서버가 불안정합니다. 다시 시도해주세요.</p>
-            )}
-          </div>
-          <div className="flex-1">
-            {selectedChatRoomId ? <ChatRoom /> : <EmptyChat />}
-          </div>
-        </div>
-      </div>
+    <div className="flex h-[52.2rem] flex-1 gap-3 overflow-hidden bg-gray-100">
+      <section className="flex w-96 flex-col rounded-xl border-r border-gray-200">
+        {isConnected ? (
+          <ChatList />
+        ) : (
+          <p>서버가 불안정합니다. 다시 시도해주세요.</p>
+        )}
+      </section>
+      <section className="flex-1">
+        {selectedChatRoomId ? <ChatRoom /> : <EmptyChat />}
+      </section>
     </div>
   );
 };

--- a/src/features/my-page/pages/partner-profile.tsx
+++ b/src/features/my-page/pages/partner-profile.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { Aside } from '../../../shared/components/layout/aside/aside';
 import { Button } from '../../../shared/components/ui';
 import { SelectBox } from '../../../shared/components/ui';
 
@@ -24,109 +23,91 @@ export const PartnerProfile = () => {
   ];
 
   return (
-    <div className="flex h-screen w-screen overflow-hidden bg-gray-100">
-      <Aside />
-      <div className="flex flex-1 flex-col">
-        <header className="h-[4.5rem] w-full shrink-0 bg-white p-6 text-black">
-          <h2>개인 정보</h2>
-        </header>
-
-        <main className="grid min-h-0 w-full flex-1 grid-cols-2 gap-3 bg-gray-100 p-5 px-[3.625rem]">
-          <section className="flex h-full w-full justify-center rounded-xl bg-white p-8">
-            <h3 className="hidden">개인 정보</h3>
-            <div className="flex w-full justify-center">
-              <ProfileForm>
-                <Input
-                  id="business-phone"
-                  label="사업장 전화번호"
-                  type="text"
-                  value={businessPhone}
-                  onChange={(e) => setBusinessPhone(e.target.value)}
-                />
-                <Input
-                  id="instagram"
-                  label="Instagram Business Account ID"
-                  type="text"
-                  prefix="@"
-                  value={instagram}
-                  onChange={(e) => setInstagram(e.target.value)}
-                />
-              </ProfileForm>
-            </div>
-          </section>
-
-          <section className="flex h-full w-full flex-col gap-10 rounded-xl bg-white px-[4.375rem] py-[3.125rem]">
-            <div className="flex flex-col gap-3">
-              <h3 className="mb-3">사업자 정보</h3>
-              <div className="flex flex-col gap-2">
-                <Input variant="horizontal" label="상호명" id="" readOnly />
-                <Input
-                  variant="horizontal"
-                  label="사업자 번호"
-                  id=""
-                  readOnly
-                />
-                <Input variant="horizontal" label="대표자명" id="" readOnly />
-                <Input variant="horizontal" label="사업자주소" id="" readOnly />
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-3">
-              <div className="flex">
-                <h3 className="mb-3">정산 계좌</h3>
-              </div>
-
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-4">
-                  <span className="min-w-28">은행</span>
-                  <SelectBox
-                    options={bankOptions}
-                    value={bank}
-                    onChange={setBank}
-                    placeholder="은행을 선택하세요"
-                    className="w-full"
-                  />
-                </div>
-                <Input variant="horizontal" label="계좌번호" id="" />
-                <Input variant="horizontal" label="예금주" id="" />
-                <div className="flex gap-4">
-                  <Input variant="horizontal" label="통장사본 업로드" id="" />
-                  <Button variant="secondaryDark" label="업로드" />
-                </div>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-3">
-              <h3 className="mb-3">세금 정보</h3>
-              <div className="flex flex-col gap-2">
-                <Input
-                  id="instagram"
-                  label="세금계산서 발행용 이메일"
-                  type="email"
-                  value={bzeemail}
-                  onChange={(e) => setBzeemail(e.target.value)}
-                />
-
-                <Input
-                  id="hometax-api-key"
-                  label="홈택스 API 연동 인증키 등록"
-                  type="text"
-                  value={hometaxApiKey}
-                  onChange={(e) => setHometaxApiKey(e.target.value)}
-                />
-              </div>
-            </div>
-          </section>
-        </main>
-
-        <div className="flex shrink-0 justify-center gap-3 py-8">
-          <Button
-            variant="secondaryLight"
-            label="취소"
-            className="w-[8.6rem]"
-          />
-          <Button variant="secondaryDark" label="저장" className="w-[8.6rem]" />
+    <div className="grid min-h-0 w-full flex-1 grid-cols-2 gap-3 bg-gray-100">
+      <section className="flex h-full w-full justify-center rounded-xl bg-white p-8">
+        <h3 className="hidden">개인 정보</h3>
+        <div className="flex w-full justify-center">
+          <ProfileForm>
+            <Input
+              id="business-phone"
+              label="사업장 전화번호"
+              type="text"
+              value={businessPhone}
+              onChange={(e) => setBusinessPhone(e.target.value)}
+            />
+            <Input
+              id="instagram"
+              label="Instagram Business Account ID"
+              type="text"
+              prefix="@"
+              value={instagram}
+              onChange={(e) => setInstagram(e.target.value)}
+            />
+          </ProfileForm>
         </div>
+      </section>
+
+      <section className="flex h-full w-full flex-col gap-10 rounded-xl bg-white px-[4.375rem] py-[3.125rem]">
+        <div className="flex flex-col gap-3">
+          <h3 className="mb-3">사업자 정보</h3>
+          <div className="flex flex-col gap-2">
+            <Input variant="horizontal" label="상호명" id="" readOnly />
+            <Input variant="horizontal" label="사업자 번호" id="" readOnly />
+            <Input variant="horizontal" label="대표자명" id="" readOnly />
+            <Input variant="horizontal" label="사업자주소" id="" readOnly />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex">
+            <h3 className="mb-3">정산 계좌</h3>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-4">
+              <span className="min-w-28">은행</span>
+              <SelectBox
+                options={bankOptions}
+                value={bank}
+                onChange={setBank}
+                placeholder="은행을 선택하세요"
+                className="w-full"
+              />
+            </div>
+            <Input variant="horizontal" label="계좌번호" id="" />
+            <Input variant="horizontal" label="예금주" id="" />
+            <div className="flex gap-4">
+              <Input variant="horizontal" label="통장사본 업로드" id="" />
+              <Button variant="secondaryDark" label="업로드" />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <h3 className="mb-3">세금 정보</h3>
+          <div className="flex flex-col gap-2">
+            <Input
+              id="instagram"
+              label="세금계산서 발행용 이메일"
+              type="email"
+              value={bzeemail}
+              onChange={(e) => setBzeemail(e.target.value)}
+            />
+
+            <Input
+              id="hometax-api-key"
+              label="홈택스 API 연동 인증키 등록"
+              type="text"
+              value={hometaxApiKey}
+              onChange={(e) => setHometaxApiKey(e.target.value)}
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="col-span-2 flex shrink-0 justify-center gap-3 py-8">
+        <Button variant="secondaryLight" label="취소" className="w-[8.6rem]" />
+        <Button variant="secondaryDark" label="저장" className="w-[8.6rem]" />
       </div>
     </div>
   );

--- a/src/features/notice/pages/partner-notice.tsx
+++ b/src/features/notice/pages/partner-notice.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from 'react';
 
-import { Aside } from '../../../shared/components/layout';
-
 import { useGetNoticeDetailQuery, useGetNoticesQuery } from '../api/notice-api';
 import type { NoticeItem } from '../types/notice-types';
 import { toNoticeItem } from '../utils/notice-utils';
@@ -42,48 +40,38 @@ export const PartnerNotice = () => {
   };
 
   return (
-    <div className="flex h-screen w-screen">
-      <Aside />
-      <div className="flex flex-1 flex-col">
-        <header className="h-[4.5rem] w-full bg-white p-6 text-black">
-          <h2>공지사항</h2>
-        </header>
-        <main className="grid w-full flex-1 grid-cols-2 gap-3 overflow-y-auto bg-gray-100 p-5 px-[3.625rem]">
-          <CommonNotice
-            target="ARTIST_SHOP"
-            noticeData={noticeData}
-            totalPages={totalPages}
-            currentPage={currentPage}
-            selectedCategory={selectedCategory}
-            onPageChange={setCurrentPage}
-            onCategoryChange={handleCategoryChange}
-            onSelectNotice={handleSelectNotice}
-          />
+    <div className="grid h-full w-full flex-1 grid-cols-2 items-stretch gap-3 overflow-y-auto bg-gray-100">
+      <CommonNotice
+        target="ARTIST_SHOP"
+        noticeData={noticeData}
+        totalPages={totalPages}
+        currentPage={currentPage}
+        selectedCategory={selectedCategory}
+        onPageChange={setCurrentPage}
+        onCategoryChange={handleCategoryChange}
+        onSelectNotice={handleSelectNotice}
+      />
 
-          <section className="flex flex-col justify-between rounded-xl bg-white px-[3.125rem] pb-[1.6875rem] pt-10">
-            <h3 className="hidden">공지사항</h3>
-            {selectedNotice ? (
-              <div>
-                <div className="mb-4 flex justify-between pb-4">
-                  <h4 className="mt-2 text-base font-medium">
-                    {selectedNotice.title}
-                  </h4>
-                  <p className="mt-2 text-sm font-normal">
-                    {selectedNotice.date}
-                  </p>
-                </div>
-                <div className="whitespace-pre-wrap text-gray-700">
-                  {selectedNotice.content}
-                </div>
-              </div>
-            ) : (
-              <div className="flex h-full items-center justify-center text-gray-400">
-                공지사항을 선택해주세요
-              </div>
-            )}
-          </section>
-        </main>
-      </div>
+      <section className="flex h-full flex-col justify-between rounded-xl bg-white px-[3.125rem] pb-[1.6875rem] pt-10">
+        <h3 className="hidden">공지사항</h3>
+        {selectedNotice ? (
+          <div>
+            <div className="mb-4 flex justify-between pb-4">
+              <h4 className="mt-2 text-base font-medium">
+                {selectedNotice.title}
+              </h4>
+              <p className="mt-2 text-sm font-normal">{selectedNotice.date}</p>
+            </div>
+            <div className="whitespace-pre-wrap text-gray-700">
+              {selectedNotice.content}
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center text-gray-400">
+            공지사항을 선택해주세요
+          </div>
+        )}
+      </section>
     </div>
   );
 };

--- a/src/features/shop/setting/pages/shop-setting-page.tsx
+++ b/src/features/shop/setting/pages/shop-setting-page.tsx
@@ -1,26 +1,15 @@
-import { Aside } from '../../../../shared/components/layout';
-
 import { ToggleSwitch } from '../../../../shared/components/ui/toggleswitch';
 
 export const ShopSettingPage = () => {
   return (
-    <div className="flex h-screen w-screen bg-gray-100">
-      <Aside />
-      <div className="flex flex-1 flex-col">
-        <header className="h-[4.5rem] w-full bg-white p-6 text-black">
-          <h2>환경 설정</h2>
-        </header>
-
-        <main className="ml-[3.25rem] mt-5 flex h-[20.5625rem] w-[42.5625rem] flex-col gap-4 rounded-2xl bg-white pb-[3.125rem] pl-[3.9375rem] pr-[5.3125rem] pt-[2.1875rem]">
-          <h3 className="text-xl">알림 설정</h3>
-          <div className="flex h-full w-full flex-col gap-[0.625rem] rounded-md bg-gray-200 px-[1.1875rem] pt-[1.625rem]">
-            <ToggleSwitch id="" label="정산알림 on/off" />
-            <ToggleSwitch id="" label="예약 취소 알림" />
-            <ToggleSwitch id="" label="신규 입점신청 알림" />
-            <ToggleSwitch id="" label="카카오톡 알림톡 수신동의" />
-            <ToggleSwitch id="" label="E-mail 수신 동의" />
-          </div>
-        </main>
+    <div className="flex h-[20.5625rem] w-[42.5625rem] flex-col gap-4 rounded-2xl bg-white pb-[3.125rem] pl-[3.9375rem] pr-[5.3125rem] pt-[2.1875rem]">
+      <h3 className="text-xl">알림 설정</h3>
+      <div className="flex h-full w-full flex-col gap-[0.625rem] rounded-md bg-gray-200 px-[1.1875rem] pt-[1.625rem]">
+        <ToggleSwitch id="" label="정산알림 on/off" />
+        <ToggleSwitch id="" label="예약 취소 알림" />
+        <ToggleSwitch id="" label="신규 입점신청 알림" />
+        <ToggleSwitch id="" label="카카오톡 알림톡 수신동의" />
+        <ToggleSwitch id="" label="E-mail 수신 동의" />
       </div>
     </div>
   );

--- a/src/features/shop/setting/pages/shop-setting-page.tsx
+++ b/src/features/shop/setting/pages/shop-setting-page.tsx
@@ -2,7 +2,7 @@ import { ToggleSwitch } from '../../../../shared/components/ui/toggleswitch';
 
 export const ShopSettingPage = () => {
   return (
-    <div className="flex h-[20.5625rem] w-[42.5625rem] flex-col gap-4 rounded-2xl bg-white pb-[3.125rem] pl-[3.9375rem] pr-[5.3125rem] pt-[2.1875rem]">
+    <section className="flex h-[20.5625rem] w-[42.5625rem] flex-col gap-4 rounded-2xl bg-white pb-[3.125rem] pl-[3.9375rem] pr-[5.3125rem] pt-[2.1875rem]">
       <h3 className="text-xl">알림 설정</h3>
       <div className="flex h-full w-full flex-col gap-[0.625rem] rounded-md bg-gray-200 px-[1.1875rem] pt-[1.625rem]">
         <ToggleSwitch id="" label="정산알림 on/off" />
@@ -11,6 +11,6 @@ export const ShopSettingPage = () => {
         <ToggleSwitch id="" label="카카오톡 알림톡 수신동의" />
         <ToggleSwitch id="" label="E-mail 수신 동의" />
       </div>
-    </div>
+    </section>
   );
 };

--- a/src/features/shop/shop-management/pages/shop-management.tsx
+++ b/src/features/shop/shop-management/pages/shop-management.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, type ChangeEvent } from 'react';
 
 import { ImagePlus, X } from 'lucide-react';
 
-import { Aside } from '../../../../shared/components/layout';
 import { Button } from '../../../../shared/components/ui';
 import { Input } from '../../../../shared/components/ui';
 
@@ -181,259 +180,249 @@ export const ShopManagement = () => {
   const isFormDisabled = mode === 'default' || mode === 'selected';
 
   return (
-    <div className="flex h-screen w-screen">
-      <Aside />
-      <div className="flex flex-1 flex-col">
-        <header className="h-[4.5rem] w-full bg-white p-6 text-black">
-          <h2>관리 홈 / 나의 소품샵 관리</h2>
-        </header>
-        <main className="grid w-full flex-1 grid-cols-2 gap-3 overflow-y-auto bg-gray-100 p-5 px-[3.625rem]">
-          {/* 클래스 등록 및 매장 운영 정보 등록 */}
-          <div className="flex flex-col gap-3">
-            <StoryManage />
-            <RegisterBusinessHour />
+    <div className="grid w-full flex-1 grid-cols-2 gap-3 overflow-y-auto bg-gray-100">
+      {/* 클래스 등록 및 매장 운영 정보 등록 */}
+      <div className="flex flex-col gap-3">
+        <StoryManage />
+        <RegisterBusinessHour />
+      </div>
+
+      {/* 클래스 등록하기 */}
+      <div className="flex h-full flex-col gap-3">
+        <section className="flex flex-col rounded-xl bg-white px-[3.125rem] pb-[1.6875rem] pt-4">
+          <div className="flex items-center justify-between border-b pb-3">
+            <h3>클래스 등록하기</h3>
+            {(mode === 'default' || mode === 'selected') && (
+              <Button
+                variant="secondaryDark"
+                className="flex items-center justify-center px-4 py-2 text-xs"
+                label="새 클래스 등록"
+                onClick={() => {
+                  setSelectedClassId(null);
+                  setImages([]);
+                  setImageFiles([]);
+                  setClassName('');
+                  setClassDescription('');
+                  setPrice('');
+                  setMaxCapacity('');
+                  setNotes('');
+                  setErrors({});
+                  setMode('registering');
+                }}
+              />
+            )}
+            {mode === 'registering' && (
+              <div className="flex gap-1">
+                <Button
+                  variant="secondaryDark"
+                  className="flex items-center justify-center px-4 py-2 text-xs"
+                  label="취소"
+                  onClick={handleCancel}
+                />
+                <Button
+                  variant="secondaryDark"
+                  className="flex items-center justify-center px-4 py-2 text-xs"
+                  label="저장"
+                  onClick={handleSave}
+                />
+              </div>
+            )}
+            {mode === 'editing' && (
+              <div className="flex gap-1">
+                <Button
+                  variant="secondaryDark"
+                  className="flex items-center justify-center px-4 py-2 text-xs"
+                  label="취소"
+                  onClick={handleCancel}
+                />
+                <Button
+                  variant="secondaryDark"
+                  className="flex items-center justify-center px-4 py-2 text-xs"
+                  label="수정"
+                  onClick={handleEditSave}
+                />
+              </div>
+            )}
           </div>
 
-          {/* 클래스 등록하기 */}
-          <div className="flex h-full flex-col gap-3">
-            <section className="flex flex-col rounded-xl bg-white px-[3.125rem] pb-[1.6875rem] pt-4">
-              <div className="flex items-center justify-between border-b pb-3">
-                <h3>클래스 등록하기</h3>
-                {(mode === 'default' || mode === 'selected') && (
-                  <Button
-                    variant="secondaryDark"
-                    className="flex items-center justify-center px-4 py-2 text-xs"
-                    label="새 클래스 등록"
-                    onClick={() => {
-                      setSelectedClassId(null);
-                      setImages([]);
-                      setImageFiles([]);
-                      setClassName('');
-                      setClassDescription('');
-                      setPrice('');
-                      setMaxCapacity('');
-                      setNotes('');
-                      setErrors({});
-                      setMode('registering');
-                    }}
-                  />
-                )}
-                {mode === 'registering' && (
-                  <div className="flex gap-1">
-                    <Button
-                      variant="secondaryDark"
-                      className="flex items-center justify-center px-4 py-2 text-xs"
-                      label="취소"
-                      onClick={handleCancel}
-                    />
-                    <Button
-                      variant="secondaryDark"
-                      className="flex items-center justify-center px-4 py-2 text-xs"
-                      label="저장"
-                      onClick={handleSave}
-                    />
-                  </div>
-                )}
-                {mode === 'editing' && (
-                  <div className="flex gap-1">
-                    <Button
-                      variant="secondaryDark"
-                      className="flex items-center justify-center px-4 py-2 text-xs"
-                      label="취소"
-                      onClick={handleCancel}
-                    />
-                    <Button
-                      variant="secondaryDark"
-                      className="flex items-center justify-center px-4 py-2 text-xs"
-                      label="수정"
-                      onClick={handleEditSave}
-                    />
-                  </div>
+          <div>
+            <form className="flex flex-col gap-3">
+              <div className="flex flex-col gap-2">
+                <p className="text-sm font-medium">
+                  클래스 이름을 등록해주세요
+                </p>
+                <Input
+                  className="w-full"
+                  disabled={isFormDisabled}
+                  value={className}
+                  onChange={(e) => {
+                    setClassName(e.target.value);
+                    clearError('className');
+                  }}
+                />
+                {errors.className && (
+                  <p className="text-sm text-red-400">{errors.className}</p>
                 )}
               </div>
 
-              <div>
-                <form className="flex flex-col gap-3">
-                  <div className="flex flex-col gap-2">
-                    <p className="text-sm font-medium">
-                      클래스 이름을 등록해주세요
-                    </p>
-                    <Input
-                      className="w-full"
-                      disabled={isFormDisabled}
-                      value={className}
-                      onChange={(e) => {
-                        setClassName(e.target.value);
-                        clearError('className');
-                      }}
-                    />
-                    {errors.className && (
-                      <p className="text-sm text-red-400">{errors.className}</p>
-                    )}
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <p className="text-sm font-medium">
-                      클래스 소개글을 작성해주세요
-                    </p>
-                    <textarea
-                      className="h-[7.0625rem] w-full resize-none rounded-lg border border-gray-500 px-3 py-2 text-sm disabled:border-gray-200 disabled:bg-white"
-                      disabled={isFormDisabled}
-                      value={classDescription}
-                      onChange={(e) => {
-                        setClassDescription(e.target.value);
-                        clearError('classDescription');
-                      }}
-                    />
-                    {errors.classDescription && (
-                      <p className="text-sm text-red-400">
-                        {errors.classDescription}
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="flex gap-2">
-                    <div className="flex w-full flex-col gap-2">
-                      <p className="text-sm font-medium">
-                        결제 금액을 작성해주세요 (1인 기준입니다)
-                      </p>
-                      <Input
-                        className="w-full"
-                        disabled={isFormDisabled}
-                        value={price}
-                        onChange={handlePriceChange}
-                      />
-                      {errors.price && (
-                        <p className="text-sm text-red-400">{errors.price}</p>
-                      )}
-                    </div>
-
-                    <div className="flex w-full flex-col gap-2">
-                      <p className="text-sm font-medium">최대 예약인원</p>
-                      <Input
-                        className="w-full"
-                        disabled={isFormDisabled}
-                        value={maxCapacity}
-                        onChange={handleMaxCapacityChange}
-                      />
-                      {errors.maxCapacity && (
-                        <p className="text-sm text-red-400">
-                          {errors.maxCapacity}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <p className="text-sm font-medium">
-                      클래스 유의 사항을 작성해주세요
-                    </p>
-                    <Input
-                      className="w-full"
-                      disabled={isFormDisabled}
-                      value={notes}
-                      onChange={(e) => {
-                        setNotes(e.target.value);
-                        clearError('notes');
-                      }}
-                    />
-                    {errors.notes && (
-                      <p className="text-sm text-red-400">{errors.notes}</p>
-                    )}
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <p className="text-sm font-medium">사진을 추가해주세요</p>
-                    <div className="flex flex-row gap-2">
-                      {images.length < 5 && (
-                        <label
-                          className={`flex h-[5.625rem] w-[5.625rem] flex-shrink-0 items-center justify-center rounded-lg bg-gray-200 ${
-                            isFormDisabled
-                              ? 'cursor-not-allowed opacity-50'
-                              : 'cursor-pointer'
-                          }`}
-                        >
-                          <ImagePlus className="h-5 w-5" />
-                          <input
-                            type="file"
-                            accept="image/jpg, image/jpeg, image/png"
-                            className="hidden"
-                            disabled={isFormDisabled}
-                            onChange={handleImageAdd}
-                          />
-                        </label>
-                      )}
-                      {images.map((url, index) => (
-                        <div
-                          key={index}
-                          className="relative h-[5.625rem] w-[5.625rem] flex-shrink-0"
-                        >
-                          <img
-                            src={url}
-                            alt={`uploaded-${index}`}
-                            className="h-full w-full rounded-lg object-cover"
-                          />
-                          <Button
-                            variant="icon"
-                            className="absolute right-1 top-1 flex h-4 w-4"
-                            onClick={() => handleImageRemove(index)}
-                            icon={<X />}
-                            disabled={isFormDisabled}
-                          />
-                        </div>
-                      ))}
-                    </div>
-                    {errors.images && (
-                      <p className="text-sm text-red-400">{errors.images}</p>
-                    )}
-                  </div>
-                </form>
+              <div className="flex flex-col gap-2">
+                <p className="text-sm font-medium">
+                  클래스 소개글을 작성해주세요
+                </p>
+                <textarea
+                  className="h-[7.0625rem] w-full resize-none rounded-lg border border-gray-500 px-3 py-2 text-sm disabled:border-gray-200 disabled:bg-white"
+                  disabled={isFormDisabled}
+                  value={classDescription}
+                  onChange={(e) => {
+                    setClassDescription(e.target.value);
+                    clearError('classDescription');
+                  }}
+                />
+                {errors.classDescription && (
+                  <p className="text-sm text-red-400">
+                    {errors.classDescription}
+                  </p>
+                )}
               </div>
-            </section>
 
-            <section className="flex h-full flex-col rounded-xl bg-white px-[3.125rem] pb-[1.6875rem] pt-4">
-              <div className="flex items-center justify-between border-b pb-3">
-                <h3>클래스 리스트</h3>
-                <div className="flex gap-1">
-                  <Button
-                    variant="secondaryLight"
-                    className="flex items-center justify-center border-[1px] px-4 py-2 text-xs"
-                    label="수정"
-                    onClick={handleEditClick}
+              <div className="flex gap-2">
+                <div className="flex w-full flex-col gap-2">
+                  <p className="text-sm font-medium">
+                    결제 금액을 작성해주세요 (1인 기준입니다)
+                  </p>
+                  <Input
+                    className="w-full"
+                    disabled={isFormDisabled}
+                    value={price}
+                    onChange={handlePriceChange}
                   />
-                  <Button
-                    variant="secondaryDark"
-                    className="flex items-center justify-center px-4 py-2 text-xs"
-                    label="삭제"
-                    onClick={handleDeleteClick}
+                  {errors.price && (
+                    <p className="text-sm text-red-400">{errors.price}</p>
+                  )}
+                </div>
+
+                <div className="flex w-full flex-col gap-2">
+                  <p className="text-sm font-medium">최대 예약인원</p>
+                  <Input
+                    className="w-full"
+                    disabled={isFormDisabled}
+                    value={maxCapacity}
+                    onChange={handleMaxCapacityChange}
                   />
+                  {errors.maxCapacity && (
+                    <p className="text-sm text-red-400">{errors.maxCapacity}</p>
+                  )}
                 </div>
               </div>
 
-              <div className="mt-4 flex gap-4 overflow-x-auto">
-                {classListData?.data.items.map((item) => (
-                  <article
-                    key={item.classId}
-                    className="flex flex-shrink-0 cursor-pointer flex-col"
-                    onClick={() => handleClassSelect(item.classId)}
-                  >
-                    <img
-                      src={item.firstImageUrl}
-                      alt="이미지"
-                      className="h-[8rem] w-[11.1875rem] bg-gray-700 object-cover"
-                    />
-                    <div className="h-[6.4375rem] w-[11.1875rem] bg-gray-200 p-4">
-                      <p className="text-xs">{item.className}</p>
-                      <span className="text-[10px]">
-                        최대인원 {item.maxCapacity.toLocaleString()}명
-                      </span>
-                    </div>
-                  </article>
-                ))}
+              <div className="flex flex-col gap-2">
+                <p className="text-sm font-medium">
+                  클래스 유의 사항을 작성해주세요
+                </p>
+                <Input
+                  className="w-full"
+                  disabled={isFormDisabled}
+                  value={notes}
+                  onChange={(e) => {
+                    setNotes(e.target.value);
+                    clearError('notes');
+                  }}
+                />
+                {errors.notes && (
+                  <p className="text-sm text-red-400">{errors.notes}</p>
+                )}
               </div>
-            </section>
+
+              <div className="flex flex-col gap-2">
+                <p className="text-sm font-medium">사진을 추가해주세요</p>
+                <div className="flex flex-row gap-2">
+                  {images.length < 5 && (
+                    <label
+                      className={`flex h-[5.625rem] w-[5.625rem] flex-shrink-0 items-center justify-center rounded-lg bg-gray-200 ${
+                        isFormDisabled
+                          ? 'cursor-not-allowed opacity-50'
+                          : 'cursor-pointer'
+                      }`}
+                    >
+                      <ImagePlus className="h-5 w-5" />
+                      <input
+                        type="file"
+                        accept="image/jpg, image/jpeg, image/png"
+                        className="hidden"
+                        disabled={isFormDisabled}
+                        onChange={handleImageAdd}
+                      />
+                    </label>
+                  )}
+                  {images.map((url, index) => (
+                    <div
+                      key={index}
+                      className="relative h-[5.625rem] w-[5.625rem] flex-shrink-0"
+                    >
+                      <img
+                        src={url}
+                        alt={`uploaded-${index}`}
+                        className="h-full w-full rounded-lg object-cover"
+                      />
+                      <Button
+                        variant="icon"
+                        className="absolute right-1 top-1 flex h-4 w-4"
+                        onClick={() => handleImageRemove(index)}
+                        icon={<X />}
+                        disabled={isFormDisabled}
+                      />
+                    </div>
+                  ))}
+                </div>
+                {errors.images && (
+                  <p className="text-sm text-red-400">{errors.images}</p>
+                )}
+              </div>
+            </form>
           </div>
-        </main>
+        </section>
+
+        <section className="flex h-full flex-col rounded-xl bg-white px-[3.125rem] pb-[1.6875rem] pt-4">
+          <div className="flex items-center justify-between border-b pb-3">
+            <h3>클래스 리스트</h3>
+            <div className="flex gap-1">
+              <Button
+                variant="secondaryLight"
+                className="flex items-center justify-center border-[1px] px-4 py-2 text-xs"
+                label="수정"
+                onClick={handleEditClick}
+              />
+              <Button
+                variant="secondaryDark"
+                className="flex items-center justify-center px-4 py-2 text-xs"
+                label="삭제"
+                onClick={handleDeleteClick}
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex gap-4 overflow-x-auto">
+            {classListData?.data.items.map((item) => (
+              <article
+                key={item.classId}
+                className="flex flex-shrink-0 cursor-pointer flex-col"
+                onClick={() => handleClassSelect(item.classId)}
+              >
+                <img
+                  src={item.firstImageUrl}
+                  alt="이미지"
+                  className="h-[8rem] w-[11.1875rem] bg-gray-700 object-cover"
+                />
+                <div className="h-[6.4375rem] w-[11.1875rem] bg-gray-200 p-4">
+                  <p className="text-xs">{item.className}</p>
+                  <span className="text-[10px]">
+                    최대인원 {item.maxCapacity.toLocaleString()}명
+                  </span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/src/shared/components/layout/aside/aside.tsx
+++ b/src/shared/components/layout/aside/aside.tsx
@@ -18,7 +18,7 @@ export const Aside = () => {
   };
 
   return (
-    <aside className="flex h-screen flex-col bg-black pb-[2.875rem] pl-[2.375rem] pr-[3.75rem] pt-[3.25rem] text-white">
+    <aside className="flex flex-col bg-black pb-[2.875rem] pl-[2.375rem] pr-[3.75rem] pt-[3.25rem] text-white">
       <section className="flex items-center gap-2 text-[1.1875rem]">
         <img src={DearObjectWhiteLogo} alt="dear objet 로고" />
         <h2>my pape</h2>

--- a/src/shared/components/layout/partner-header.tsx
+++ b/src/shared/components/layout/partner-header.tsx
@@ -1,0 +1,25 @@
+import { useLocation } from 'react-router';
+
+import { ROUTE_LABELS } from '../../constants';
+
+export const PartnerHeader = () => {
+  const location = useLocation();
+
+  const getRouteLabel = (pathname: string) => {
+    const matched = Object.keys(ROUTE_LABELS)
+      .filter((route) => pathname.startsWith(route))
+      .sort((a, b) => b.length - a.length)[0];
+
+    return ROUTE_LABELS[matched] ?? { main: '', sub: '' };
+  };
+
+  const { main, sub } = getRouteLabel(location.pathname);
+
+  return (
+    <header className="flex h-[4.5rem] w-full items-center bg-white px-6">
+      <h2 className="text-lg font-semibold">
+        {sub ? `${main} / ${sub}` : main}
+      </h2>
+    </header>
+  );
+};

--- a/src/shared/components/layout/partner-layout.tsx
+++ b/src/shared/components/layout/partner-layout.tsx
@@ -1,11 +1,22 @@
 import { Outlet } from 'react-router';
 
+import { Aside } from './aside/aside';
+import { PartnerHeader } from './partner-header';
+
 export const PartnerLayout = () => {
   return (
-    <div className="flex min-h-screen flex-col">
-      <main className="flex-1">
-        <Outlet />
-      </main>
+    <div className="flex min-h-screen w-full">
+      <Aside />
+
+      <div className="flex flex-1 flex-col">
+        <PartnerHeader />
+
+        <main className="flex-1 bg-gray-100">
+          <div className="mx-auto w-full max-w-[120rem] p-5 px-[3.625rem]">
+            <Outlet />
+          </div>
+        </main>
+      </div>
     </div>
   );
 };

--- a/src/shared/components/layout/partner-layout.tsx
+++ b/src/shared/components/layout/partner-layout.tsx
@@ -12,7 +12,7 @@ export const PartnerLayout = () => {
         <PartnerHeader />
 
         <main className="flex-1 bg-gray-100">
-          <div className="mx-auto w-full max-w-[120rem] p-5 px-[3.625rem]">
+          <div className="mx-auto h-full w-full max-w-[120rem] p-5 px-[3.625rem]">
             <Outlet />
           </div>
         </main>

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -2,6 +2,6 @@ export { createBaseQuery, API_BASE_URL } from './api-config';
 
 export { ROUTES } from './routes';
 
-export { NAV_ITEMS, INFO_LINKS, PARTNER_LINKS } from './layout';
+export { NAV_ITEMS, INFO_LINKS, PARTNER_LINKS, ROUTE_LABELS } from './layout';
 
 export { USER_ROLE, type UserRole } from './user-role';

--- a/src/shared/constants/layout.ts
+++ b/src/shared/constants/layout.ts
@@ -26,3 +26,36 @@ export const PARTNER_LINKS = [
     isBold: true,
   },
 ] as const;
+
+// partner header
+export const ROUTE_LABELS: Record<string, { main: string; sub?: string }> = {
+  // shop
+  '/shop/dashboard': { main: '관리홈', sub: '대시보드' },
+  '/shop/manage': { main: '관리홈', sub: '나의 소품샵 관리' },
+  '/shop/manage/reservations': { main: '관리홈', sub: '클래스 예약 관리' },
+
+  '/shop/artists': { main: '입점관리', sub: '작가 리스트' },
+  '/shop/inventory': { main: '입점관리', sub: '품목 및 재고관리' },
+  '/shop/contracts': { main: '입점관리', sub: '계약서 관리' },
+
+  '/shop/settlements': { main: '정산관리', sub: '정산금액 계산' },
+
+  '/shop/messages': { main: '마이페이지', sub: '메세지' },
+  '/shop/notices': { main: '공지사항' },
+  '/shop/profile': { main: '개인정보' },
+  '/shop/settings': { main: '환경설정' },
+
+  // artist
+  '/artist/dashboard': { main: '관리홈', sub: '대시보드' },
+
+  '/artist/inventory': { main: '입점관리', sub: '품목 및 재고관리' },
+  '/artist/shops': { main: '입점관리', sub: '입점처 리스트' },
+  '/artist/shipments': { main: '입점관리', sub: '출고관리' },
+
+  '/artist/settlements': { main: '정산관리', sub: '정산관리' },
+
+  '/artist/messages': { main: '마이페이지', sub: '메세지' },
+  '/artist/notices': { main: '공지사항' },
+  '/artist/profile': { main: '개인정보' },
+  '/artist/settings': { main: '환경설정' },
+};


### PR DESCRIPTION
* partner-layout
  - shop, artist 회원용 layout
  - Aside, partner-header component로 구성

* partner-header
  - router-label mapping 구조로 url을 읽어 header에 자동으로 표시하도록 함
  - shared/constants/layout.ts에 관련 변수 추가

* partner-layout 변화에 따라 기존에 작업되어 있던 파일들 layout 수정
  - shop-management, partner-notice, shop-setting-page, artist-setting-page, partner-profile, chat 파일이 해당함