### PR TITLE
feat: 스토리 탭 api 연결

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -14,7 +14,7 @@ import {
   classApi,
   storyApi,
 } from '../features/shop/shop-management';
-import { mapApi, oneDayClassApi } from '../features/map';
+import { mapApi, oneDayClassApi, mapStoryApi } from '../features/map';
 import { chatApi } from '../features/chat/api/chat-api';
 import { myPageApi } from '../features/my-page/api/my-page-api';
 import { classReservationApi } from '../features/shop/class-reservation-management/api/class-reservation-api';
@@ -39,6 +39,7 @@ export const store = configureStore({
     [businessHoursApi.reducerPath]: businessHoursApi.reducer,
     [mapApi.reducerPath]: mapApi.reducer,
     [oneDayClassApi.reducerPath]: oneDayClassApi.reducer,
+    [mapStoryApi.reducerPath]: mapStoryApi.reducer,
     [chatApi.reducerPath]: chatApi.reducer,
     [myPageApi.reducerPath]: myPageApi.reducer,
     [userMeApi.reducerPath]: userMeApi.reducer,
@@ -58,6 +59,7 @@ export const store = configureStore({
       .concat(businessHoursApi.middleware)
       .concat(mapApi.middleware)
       .concat(oneDayClassApi.middleware)
+      .concat(mapStoryApi.middleware)
       .concat(chatApi.middleware)
       .concat(myPageApi.middleware)
       .concat(userMeApi.middleware)

--- a/src/features/map/api/map-story-api.ts
+++ b/src/features/map/api/map-story-api.ts
@@ -1,0 +1,27 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import { createBaseQuery } from '../../../shared/constants';
+
+import type { MapStoryListResponse } from '../types/map-story-types';
+
+export const mapStoryApi = createApi({
+  reducerPath: 'mapStoryApi',
+  baseQuery: createBaseQuery(),
+  tagTypes: ['MapStory'],
+  endpoints: (builder) => ({
+    getShopStories: builder.query<
+      MapStoryListResponse,
+      { shopId: number; page: number }
+    >({
+      query: ({ shopId, page }) => ({
+        url: `/api/v1/shops/${shopId}/stories`,
+        params: { page },
+      }),
+      transformResponse: (response: { data: MapStoryListResponse }) =>
+        response.data,
+      providesTags: ['MapStory'],
+    }),
+  }),
+});
+
+export const { useLazyGetShopStoriesQuery } = mapStoryApi;

--- a/src/features/map/components/map-aside.tsx
+++ b/src/features/map/components/map-aside.tsx
@@ -188,7 +188,7 @@ export const MapAside = ({ shopDetail, shopId }: ShopPanelProps) => {
 
       {/* 탭 컨텐츠 */}
       <div className="flex-1">
-        {activeTab === '스토리' && <StoryTab />}
+        {activeTab === '스토리' && shopId && <StoryTab shopId={shopId} />}
         {activeTab === '원데이클래스' && shopId && (
           <OneDayClassTab shopId={shopId} shopName={shopDetail.shopName} />
         )}

--- a/src/features/map/components/story-tab.tsx
+++ b/src/features/map/components/story-tab.tsx
@@ -1,61 +1,60 @@
+import { useCallback } from 'react';
+
 import { useInfiniteScroll } from '../hooks/use-infinite-scroll';
 
-interface Story {
-  storyId: number;
-  imageUrl: string | null;
-  title: string;
-  content: string;
-  createdAt: string;
-}
+import { useLazyGetShopStoriesQuery } from '../api/map-story-api';
+import type { MapStoryItem, StoryTabProps } from '../types/map-story-types';
 
-// 더미 데이터 생성 함수
-const fetchStories = async (page: number) => {
-  await new Promise((resolve) => setTimeout(resolve, 500)); // 로딩 시뮬레이션
+const formatDate = (createdAt: string) =>
+  createdAt.slice(0, 10).replace(/-/g, '.');
 
-  const items: Story[] = Array.from({ length: 5 }, (_, i) => ({
-    storyId: (page - 1) * 5 + i + 1,
-    imageUrl: null,
-    title: `스토리 제목 ${(page - 1) * 5 + i + 1}`,
-    content: '소품샵의 새로운 소식을 전해드립니다.',
-    createdAt: '2025.09.16',
-  }));
+export const StoryTab = ({ shopId }: StoryTabProps) => {
+  const [fetchStories] = useLazyGetShopStoriesQuery();
 
-  return { items, hasMore: page < 5 };
-};
+  const fetchData = useCallback(
+    async (page: number) => {
+      const result = await fetchStories({ shopId, page }).unwrap();
+      return {
+        items: result.items,
+        hasMore: page < result.totalPages,
+      };
+    },
+    [fetchStories, shopId]
+  );
 
-export const StoryTab = () => {
   const { items, isLoading, hasMore, observerTargetRef } =
-    useInfiniteScroll<Story>({
-      fetchData: fetchStories,
-    });
+    useInfiniteScroll<MapStoryItem>({ fetchData });
 
   return (
     <div className="flex flex-col divide-y divide-theme-200">
       {items.map((story) => (
         <div key={story.storyId} className="flex flex-col gap-3 p-4">
-          {/* 이미지 */}
           <div className="aspect-video w-full overflow-hidden rounded bg-theme-200">
-            {story.imageUrl && (
-              <img
-                src={story.imageUrl}
-                alt={story.title}
-                className="h-full w-full object-cover"
-              />
-            )}
+            <img
+              src={story.thumbnailImageUrl}
+              alt={story.title}
+              className="h-full w-full object-cover"
+            />
           </div>
-          {/* 제목 */}
-          <p className="font-semibold text-theme-900">{story.title}</p>
-          {/* 내용 */}
-          <p className="text-sm text-theme-700">{story.content}</p>
-          {/* 작성일 */}
-          <p className="text-right text-xs text-theme-500">{story.createdAt}</p>
+          <p className="break-all font-semibold text-theme-900">
+            {story.title}
+          </p>
+          <p className="break-all text-sm text-theme-700">{story.content}</p>
+          <p className="text-right text-xs text-theme-500">
+            {formatDate(story.createdAt)}
+          </p>
         </div>
       ))}
-      {/* IntersectionObserver 타겟 */}
+
       <div ref={observerTargetRef} className="py-2 text-center">
         {isLoading && <p className="text-sm text-theme-300">불러오는 중...</p>}
-        {!hasMore && (
+        {!hasMore && items.length > 0 && (
           <p className="text-sm text-theme-300">마지막 스토리입니다.</p>
+        )}
+        {!isLoading && items.length === 0 && (
+          <p className="py-6 text-center text-xs text-theme-300">
+            등록된 스토리가 없습니다.
+          </p>
         )}
       </div>
     </div>

--- a/src/features/map/index.ts
+++ b/src/features/map/index.ts
@@ -5,5 +5,5 @@ export {
   useGetShopMarkersQuery,
   useGetShopDetailQuery,
 } from './api/map-api';
-
 export { oneDayClassApi } from './api/one-day-class-api';
+export { mapStoryApi } from './api/map-story-api';

--- a/src/features/map/types/map-story-types.ts
+++ b/src/features/map/types/map-story-types.ts
@@ -1,0 +1,17 @@
+export interface MapStoryItem {
+  storyId: number;
+  thumbnailImageUrl: string;
+  title: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface MapStoryListResponse {
+  items: MapStoryItem[];
+  page: number;
+  totalPages: number;
+}
+
+export interface StoryTabProps {
+  shopId: number;
+}


### PR DESCRIPTION

*map-api.ts
  - `getShopStories` 엔드포인트 추가 (`GET /api/v1/shops/{shopId}/stories`)
  - `useLazyGetShopStoriesQuery` export 추가

*map-types.ts
  - `StoryItem` 인터페이스 추가
  - `StoryListResponse` 인터페이스 추가

*story-tab.tsx
  - 더미 데이터 제거
  - `useLazyGetShopStoriesQuery` + `useInfiniteScroll` 훅으로 무한스크롤 API 연동
  - `shopId` prop 추가
  - 스토리 없을 때 빈 상태 메시지 처리
  - 텍스트 overflow 처리 (`break-all`)

*map-aside.tsx
  - `StoryTab`에 `shopId` prop 전달