### PR TITLE
Feature/post - main page postList

### DIFF
--- a/src/features/post/api/post-api.ts
+++ b/src/features/post/api/post-api.ts
@@ -64,6 +64,7 @@ export const postApi = createApi({
 });
 
 export const {
+  useGetAllPostsQuery,
   useLazyGetAllPostsQuery,
   useGetUserPostsQuery,
   useLazyGetUserPostsQuery,

--- a/src/features/post/pages/post.tsx
+++ b/src/features/post/pages/post.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router';
 
 import { useAppSelector } from '../../../app/hooks';
 
@@ -18,6 +19,8 @@ export const Post = () => {
   const [showCreate, setShowCreate] = useState(false);
   const [selectedPost, setSelectedPost] = useState<PostDetail | null>(null);
   const [gridKey, setGridKey] = useState(0);
+
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [triggerGetAllPosts] = useLazyGetAllPostsQuery();
   const [triggerGetPost] = useLazyGetPostQuery();
@@ -71,6 +74,24 @@ export const Post = () => {
     }
   };
 
+  const handleCloseModal = () => {
+    setSelectedPost(null);
+    if (searchParams.has('id')) {
+      searchParams.delete('id');
+      setSearchParams(searchParams, { replace: true });
+    }
+  };
+
+  useEffect(() => {
+    const postId = searchParams.get('id');
+    if (!postId) return;
+
+    triggerGetPost(Number(postId))
+      .unwrap()
+      .then((detail) => setSelectedPost(detail))
+      .catch(() => alert('포스트를 불러올 수 없습니다.'));
+  }, []);
+
   return (
     <div className="relative min-h-screen bg-white">
       {user && (
@@ -101,7 +122,7 @@ export const Post = () => {
         <PostViewModal
           post={selectedPost}
           user={user}
-          onClose={() => setSelectedPost(null)}
+          onClose={handleCloseModal}
           onDelete={handleDeletePost}
         />
       )}

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -4,15 +4,18 @@ import { ChevronRight, ChevronLeft } from 'lucide-react';
 
 import { useAppSelector } from '../../app/hooks';
 import { Button } from '../../shared/components/ui';
-import { API_BASE_URL } from '../../shared/constants';
+import { API_BASE_URL, ROUTES } from '../../shared/constants';
+
 import { useGetNoticesQuery } from '../../features/notice/api/notice-api';
 import { CATEGORY_LABEL } from '../../features/notice/constants/notice-constants';
 import { FestivalSection } from '../../features/festival/components/festival-section';
+import { useGetAllPostsQuery } from '../../features/post/api/post-api';
 
 import KakaoLogo from '../../assets/kakao-logo.svg';
 import CatImg from '../../assets/cat.png';
 
 const HOME_NOTICES_PER_PAGE = 5;
+const HOME_POSTS_LIMIT = 4;
 
 export const HomePage = () => {
   const [currentNoticePage, setCurrentNoticePage] = useState(1);
@@ -30,6 +33,8 @@ export const HomePage = () => {
     (currentNoticePage - 1) * HOME_NOTICES_PER_PAGE,
     currentNoticePage * HOME_NOTICES_PER_PAGE
   );
+  const { data: postData } = useGetAllPostsQuery(1);
+  const latestPosts = (postData?.items ?? []).slice(0, HOME_POSTS_LIMIT);
 
   const handleNoticePrevPage = () => {
     if (currentNoticePage > 1) setCurrentNoticePage(currentNoticePage - 1);
@@ -53,18 +58,50 @@ export const HomePage = () => {
 
         <section className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
           <h2 className="sr-only">포스트</h2>
-          <div className="h-[21rem] rounded-sm border border-gray-300">
-            포스트
-          </div>
-          <div className="h-[21rem] rounded-sm border border-gray-300">
-            포스트
-          </div>
-          <div className="h-[21rem] rounded-sm border border-gray-300">
-            포스트
-          </div>
-          <div className="h-[21rem] rounded-sm border border-gray-300">
-            포스트
-          </div>
+          {latestPosts.length === 0
+            ? Array.from({ length: HOME_POSTS_LIMIT }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-[21rem] rounded-sm border border-gray-300"
+                />
+              ))
+            : latestPosts.map((post) => (
+                <button
+                  key={post.postId}
+                  onClick={() => navigate(`${ROUTES.POSTS}?id=${post.postId}`)}
+                  className="group relative h-[21rem] overflow-hidden rounded-sm border border-gray-300 focus:outline-none"
+                >
+                  {post.thumbnailUrl ? (
+                    <img
+                      src={post.thumbnailUrl}
+                      alt={`${post.authorName}의 포스트`}
+                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    />
+                  ) : (
+                    <div className="h-full w-full bg-theme-200" />
+                  )}
+
+                  {/* 하단 작성자 정보 오버레이 */}
+                  <div className="absolute bottom-0 left-0 right-0 flex items-center gap-2 bg-white px-3 py-3">
+                    {post.authorProfileUrl ? (
+                      <div className="h-7 w-7 shrink-0 overflow-hidden rounded-full">
+                        <img
+                          src={post.authorProfileUrl}
+                          alt={post.authorName}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-medium">
+                        {post.authorName[0]}
+                      </div>
+                    )}
+                    <span className="truncate text-xs font-medium text-gray-700">
+                      {post.authorName}
+                    </span>
+                  </div>
+                </button>
+              ))}
         </section>
       </div>
 

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -81,7 +81,8 @@ export const HomePage = () => {
                     <div className="h-full w-full bg-theme-200" />
                   )}
 
-                  {/* 하단 작성자 정보 오버레이 */}
+                  <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-black/10 to-transparent" />
+
                   <div className="absolute bottom-0 left-0 right-0 flex items-center gap-2 bg-white px-3 py-3">
                     {post.authorProfileUrl ? (
                       <div className="h-7 w-7 shrink-0 overflow-hidden rounded-full">


### PR DESCRIPTION
* `features/post/api/post-api.ts`
  - `useGetAllPostsQuery` 훅 export 추가

* `pages/home/home-page.tsx`
  - `useGetAllPostsQuery`로 최신 포스트 1페이지 fetch 후 4개 슬라이싱하여 렌더링
  - 데이터 없거나 로딩 중일 때 placeholder 유지로 레이아웃 안정성 확보
  - 포스트 카드 클릭 시 `/posts?id={postId}`로 이동
  - 포스트 하단 이미지에 `bg-gradient-to-t` 그라디언트 shadow 추가
  - 썸네일 없는 포스트 `bg-theme-200` fallback 처리

* `features/post/pages/post.tsx`
  - `useSearchParams`로 URL의 `?id` 쿼리 파라미터 감지
  - 마운트 시 `?id` 존재하면 해당 포스트 자동 fetch 후 `PostViewModal` 오픈
  - 모달 닫기 시 `searchParams.delete('id')` + `replace: true`로 히스토리 오염 없이 파라미터 제거