### PR TITLE
Feature/map like - 뒤로가기 버튼 추가 및 찜 기능 수정

### DIFF
--- a/src/features/map/components/map-aside.tsx
+++ b/src/features/map/components/map-aside.tsx
@@ -68,7 +68,9 @@ export const MapAside = ({ shopDetail, shopId }: ShopPanelProps) => {
 
   useEffect(() => {
     setIsFavorited(shopDetail?.isFavorite ?? false);
-  }, [shopDetail?.isFavorite]);
+    // shopId 변경 시에만 초기화하는 것이 의도적 - isFavorite 값이 같아도 샵이 바뀌면 리셋되어야 함
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shopId]);
 
   useEffect(() => {
     setActiveTab('스토리');

--- a/src/features/map/components/map-search-bar.tsx
+++ b/src/features/map/components/map-search-bar.tsx
@@ -1,5 +1,8 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 import { Search, X } from 'lucide-react';
+
+import LeftShiftIcon from '../../../assets/left-shift.svg';
 
 import type { ShopMapItem } from '../types/map-types';
 
@@ -9,6 +12,9 @@ interface MapSearchBarProps {
 }
 
 export const MapSearchBar = ({ shops, onSelectShop }: MapSearchBarProps) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as { from?: string })?.from ?? '/';
   const [value, setValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -51,6 +57,10 @@ export const MapSearchBar = ({ shops, onSelectShop }: MapSearchBarProps) => {
   return (
     <div ref={containerRef} className="relative mx-2 my-2.5">
       <div className="flex items-center gap-2 rounded-lg border border-theme-300 px-3 py-2">
+        {/* 뒤로가기 버튼*/}
+        <button onClick={() => navigate(from)} className="shrink-0">
+          <img src={LeftShiftIcon} alt="뒤로가기" className="h-4 w-4" />
+        </button>
         <Search className="h-4 w-4 shrink-0 text-theme-300" />
         <input
           type="text"

--- a/src/features/map/components/map-search-bar.tsx
+++ b/src/features/map/components/map-search-bar.tsx
@@ -55,12 +55,17 @@ export const MapSearchBar = ({ shops, onSelectShop }: MapSearchBarProps) => {
   }, []);
 
   return (
-    <div ref={containerRef} className="relative mx-2 my-2.5">
-      <div className="flex items-center gap-2 rounded-lg border border-theme-300 px-3 py-2">
-        {/* 뒤로가기 버튼*/}
-        <button onClick={() => navigate(from)} className="shrink-0">
-          <img src={LeftShiftIcon} alt="뒤로가기" className="h-4 w-4" />
-        </button>
+    <div
+      ref={containerRef}
+      className="relative mx-2 my-2.5 flex items-center gap-2"
+    >
+      {/* 뒤로가기 버튼 */}
+      <button onClick={() => navigate(from)} className="shrink-0">
+        <img src={LeftShiftIcon} alt="뒤로가기" className="h-4 w-4" />
+      </button>
+
+      {/* 검색창 */}
+      <div className="flex flex-1 items-center gap-2 rounded-lg border border-theme-300 px-3 py-2">
         <Search className="h-4 w-4 shrink-0 text-theme-300" />
         <input
           type="text"
@@ -82,7 +87,7 @@ export const MapSearchBar = ({ shops, onSelectShop }: MapSearchBarProps) => {
 
       {/* 검색 결과 드롭다운 */}
       {isOpen && value.trim() && (
-        <div className="absolute left-0 right-0 z-10 mt-1 overflow-hidden rounded-lg border border-theme-200 bg-white shadow-md">
+        <div className="absolute left-6 right-0 top-full z-10 mt-1 overflow-hidden rounded-lg border border-theme-200 bg-white shadow-md">
           {filteredShops.length > 0 ? (
             <ul className="max-h-[16rem] overflow-y-auto [&::-webkit-scrollbar]:hidden">
               {filteredShops.map((shop) => (

--- a/src/shared/components/layout/header.tsx
+++ b/src/shared/components/layout/header.tsx
@@ -1,5 +1,6 @@
-import { Link, NavLink } from 'react-router';
+import { Link, NavLink, useLocation } from 'react-router';
 import { useSelector } from 'react-redux';
+import { UserPlus } from 'lucide-react';
 
 import type { RootState } from '../../../app/store';
 import { ROUTES, NAV_ITEMS, USER_ROLE } from '../../constants';
@@ -10,9 +11,9 @@ import DearObjetBlackLogo from '../../../assets/dear-objet-black-logo.svg';
 import UserRoundIcon from '../../../assets/user-round.svg';
 import { useAppDispatch } from '../../../app/hooks';
 import { useLogoutMutation, clearAuth } from '../../../features/auth';
-import { UserPlus } from 'lucide-react';
 
 export const Header = () => {
+  const location = useLocation();
   const dispatch = useAppDispatch();
   const [logout] = useLogoutMutation();
   const user = useSelector((state: RootState) => state.auth.user);
@@ -70,6 +71,7 @@ export const Header = () => {
                 <li key={to}>
                   <NavLink
                     to={to}
+                    state={{ from: location.pathname }}
                     className={({ isActive }) =>
                       [
                         'text-base font-semibold transition-colors duration-150',


### PR DESCRIPTION
* 찜 기능 use Effect 의존성 값 (shopDetail -> shopId) 수정하여 문제점 해결
  - A, B 소품샵 모두 찜 되어있는 경우 A소품샵의 찜 기능을 해제하고 B소품샵을 조회하면  B소품샵도 찜 기능이 해제된 것 처럼 보이는 문제점 수정. 

* map-search-bar.tsx 에 뒤로가기 버튼 추가
  - 뒤로가기 버튼 추가 
  - map 페이지 접속 직전의 값을 useLocation.pathname에 저장(Header.tsx에서 저장)하여 뒤로가기 버튼 클릭시 map 페이지 이전의 페이지로 이동

* header.tsx
  - useLocation 추가하여 pathname에 직전 페이지 값 저장하도록 변경