### PR TITLE
feat: map-review api 연결 및 ui 수정

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -20,6 +20,7 @@ import {
   oneDayClassApi,
   mapStoryApi,
   favoriteApi,
+  reviewApi,
 } from '../features/map';
 import { chatApi } from '../features/chat/api/chat-api';
 import { myPageApi } from '../features/my-page/api/my-page-api';
@@ -52,6 +53,7 @@ export const store = configureStore({
     [oneDayClassApi.reducerPath]: oneDayClassApi.reducer,
     [mapStoryApi.reducerPath]: mapStoryApi.reducer,
     [favoriteApi.reducerPath]: favoriteApi.reducer,
+    [reviewApi.reducerPath]: reviewApi.reducer,
     [chatApi.reducerPath]: chatApi.reducer,
     [myPageApi.reducerPath]: myPageApi.reducer,
     [userMeApi.reducerPath]: userMeApi.reducer,
@@ -78,6 +80,7 @@ export const store = configureStore({
       .concat(oneDayClassApi.middleware)
       .concat(mapStoryApi.middleware)
       .concat(favoriteApi.middleware)
+      .concat(reviewApi.middleware)
       .concat(chatApi.middleware)
       .concat(myPageApi.middleware)
       .concat(userMeApi.middleware)

--- a/src/features/map/api/review-api.ts
+++ b/src/features/map/api/review-api.ts
@@ -1,0 +1,71 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import { createBaseQuery } from '../../../shared/constants';
+import type { ApiResponse } from '../../../shared/types';
+import type {
+  ShopReviewItem,
+  ShopReviewListResponse,
+} from '../types/review-types';
+
+export const reviewApi = createApi({
+  reducerPath: 'reviewApi',
+  baseQuery: createBaseQuery(),
+  tagTypes: ['Review'],
+  endpoints: (builder) => ({
+    getShopReviews: builder.query<
+      ShopReviewListResponse,
+      { shopId: number; cursorId?: number | null; size?: number }
+    >({
+      query: ({ shopId, cursorId, size = 10 }) => ({
+        url: `/api/v1/shops/${shopId}/reviews`,
+        params: {
+          ...(cursorId != null && { cursorId }),
+          size,
+        },
+      }),
+      transformResponse: (res: ApiResponse<ShopReviewListResponse>) => res.data,
+      providesTags: ['Review'],
+    }),
+
+    createShopReview: builder.mutation<
+      ShopReviewItem,
+      { shopId: number; formData: FormData }
+    >({
+      query: ({ shopId, formData }) => ({
+        url: `/api/v1/shops/${shopId}/reviews`,
+        method: 'POST',
+        body: formData,
+      }),
+      transformResponse: (res: ApiResponse<ShopReviewItem>) => res.data,
+    }),
+
+    updateShopReview: builder.mutation<
+      ShopReviewItem,
+      { shopId: number; reviewId: number; formData: FormData }
+    >({
+      query: ({ shopId, reviewId, formData }) => ({
+        url: `/api/v1/shops/${shopId}/reviews/${reviewId}`,
+        method: 'PUT',
+        body: formData,
+      }),
+      transformResponse: (res: ApiResponse<ShopReviewItem>) => res.data,
+    }),
+
+    deleteShopReview: builder.mutation<
+      void,
+      { shopId: number; reviewId: number }
+    >({
+      query: ({ shopId, reviewId }) => ({
+        url: `/api/v1/shops/${shopId}/reviews/${reviewId}`,
+        method: 'DELETE',
+      }),
+    }),
+  }),
+});
+
+export const {
+  useLazyGetShopReviewsQuery,
+  useCreateShopReviewMutation,
+  useUpdateShopReviewMutation,
+  useDeleteShopReviewMutation,
+} = reviewApi;

--- a/src/features/map/components/map-aside.tsx
+++ b/src/features/map/components/map-aside.tsx
@@ -253,7 +253,9 @@ export const MapAside = ({ shopDetail, shopId }: ShopPanelProps) => {
           <OneDayClassTab shopId={shopId} shopName={shopDetail.shopName} />
         )}
         {activeTab === '입점작가' && <ArtistTab />}
-        {activeTab === '리뷰' && <ReviewTab />}
+        {activeTab === '리뷰' && shopId !== null && (
+          <ReviewTab shopId={shopId} />
+        )}
         {activeTab === '인근놀거리' && <NearbyTab />}
       </div>
     </div>

--- a/src/features/map/components/review-tab.tsx
+++ b/src/features/map/components/review-tab.tsx
@@ -1,95 +1,257 @@
-import { useEffect, useRef, useState, type ChangeEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+} from 'react';
 import { MoreVertical, ImagePlus } from 'lucide-react';
 
 import { Button } from '../../../shared/components/ui';
-
 import { ExpandableText } from './expandable-text';
-import { useInfiniteScroll } from '../hooks/use-infinite-scroll';
 
-interface Review {
-  reviewId: number;
-  profileImageUrl: string | null;
-  name: string;
-  content: string;
-  imageUrl: string | null;
-  createdAt: string;
+import {
+  useLazyGetShopReviewsQuery,
+  useCreateShopReviewMutation,
+  useUpdateShopReviewMutation,
+  useDeleteShopReviewMutation,
+} from '../api/review-api';
+import type { ShopReviewItem } from '../types/review-types';
+
+interface ReviewTabProps {
+  shopId: number;
 }
 
-const fetchReviews = async (page: number) => {
-  await new Promise((resolve) => setTimeout(resolve, 500));
+type Mode = 'list' | 'write' | 'edit';
 
-  const items: Review[] = Array.from({ length: 3 }, (_, i) => ({
-    reviewId: (page - 1) * 3 + i + 1,
-    profileImageUrl: null,
-    name: `리뷰어 ${(page - 1) * 3 + i + 1}`,
-    content:
-      '소품샵에서 진행된 키링 만들기 원데이 클래스에 다녀왔어요 🥰\n정말 좋았습니다!',
-    imageUrl: null,
-    createdAt: '2025.09.16',
-  }));
+const formatDate = (dateStr: string) => dateStr.slice(0, 10).replace(/-/g, '.');
 
-  return { items, hasMore: page < 3 };
+const buildFormData = (
+  title: string,
+  content: string,
+  image: File | null
+): FormData => {
+  const formData = new FormData();
+  formData.append(
+    'request',
+    new Blob([JSON.stringify({ title, content })], { type: 'application/json' })
+  );
+  if (image) formData.append('image', image);
+  return formData;
 };
 
-export const ReviewTab = () => {
-  const [isWriting, setIsWriting] = useState(false);
+export const ReviewTab = ({ shopId }: ReviewTabProps) => {
+  const [mode, setMode] = useState<Mode>('list');
+  const [editTarget, setEditTarget] = useState<ShopReviewItem | null>(null);
   const [openMenuId, setOpenMenuId] = useState<number | null>(null);
   const [reviewImage, setReviewImage] = useState<File | null>(null);
   const [reviewTitle, setReviewTitle] = useState('');
   const [reviewContent, setReviewContent] = useState('');
+
+  const [reviews, setReviews] = useState<ShopReviewItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  // ref로 커서·로딩 상태 관리 → 클로저 stale 방지
+  const stateRef = useRef({
+    cursor: null as number | null,
+    loading: false,
+    hasMore: true,
+  });
+  const observerTargetRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
 
-  const { items, isLoading, hasMore, observerTargetRef } =
-    useInfiniteScroll<Review>({
-      fetchData: fetchReviews,
-    });
+  const [fetchReviews] = useLazyGetShopReviewsQuery();
+  const [createReview, { isLoading: isCreating }] =
+    useCreateShopReviewMutation();
+  const [updateReview, { isLoading: isUpdating }] =
+    useUpdateShopReviewMutation();
+  const [deleteReview] = useDeleteShopReviewMutation();
 
-  const handleImageClick = () => fileInputRef.current?.click();
+  // 첫 페이지 로드 (shopId 변경 시 상태 초기화 포함)
+  const loadInitial = useCallback(() => {
+    stateRef.current = { cursor: null, loading: true, hasMore: true };
+    setReviews([]);
+    setHasMore(true);
+    setIsLoading(true);
+
+    fetchReviews({ shopId, cursorId: null })
+      .unwrap()
+      .then((res) => {
+        setReviews(res.items);
+        stateRef.current.cursor = res.nextCursorId;
+        stateRef.current.hasMore = res.hasNext;
+        setHasMore(res.hasNext);
+      })
+      .catch(() => {})
+      .finally(() => {
+        stateRef.current.loading = false;
+        setIsLoading(false);
+      });
+  }, [fetchReviews, shopId]);
+
+  // 커서 기반 추가 로드
+  const loadMore = useCallback(() => {
+    const s = stateRef.current;
+    if (s.loading || !s.hasMore) return;
+    s.loading = true;
+    setIsLoading(true);
+
+    fetchReviews({ shopId, cursorId: s.cursor })
+      .unwrap()
+      .then((res) => {
+        setReviews((prev) => [...prev, ...res.items]);
+        stateRef.current.cursor = res.nextCursorId;
+        stateRef.current.hasMore = res.hasNext;
+        setHasMore(res.hasNext);
+      })
+      .catch(() => {})
+      .finally(() => {
+        stateRef.current.loading = false;
+        setIsLoading(false);
+      });
+  }, [fetchReviews, shopId]);
+
+  useEffect(() => {
+    loadInitial();
+    setMode('list');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shopId]);
+
+  // 무한 스크롤 observer
+  useEffect(() => {
+    const target = observerTargetRef.current;
+    if (!target) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { threshold: 0.1 }
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  // 메뉴 외부 클릭 닫기
+  useEffect(() => {
+    if (openMenuId === null) return;
+    const handle = () => setOpenMenuId(null);
+    document.addEventListener('mousedown', handle);
+    return () => document.removeEventListener('mousedown', handle);
+  }, [openMenuId]);
+
+  const resetForm = () => {
+    setReviewTitle('');
+    setReviewContent('');
+    setReviewImage(null);
+    setEditTarget(null);
+  };
+
+  const handleOpenWrite = () => {
+    resetForm();
+    setMode('write');
+  };
+
+  const handleOpenEdit = (review: ShopReviewItem) => {
+    setEditTarget(review);
+    setReviewTitle(review.title);
+    setReviewContent(review.content);
+    setReviewImage(null);
+    setOpenMenuId(null);
+    setMode('edit');
+  };
+
+  const handleCancel = () => {
+    resetForm();
+    setMode('list');
+  };
 
   const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.[0]) setReviewImage(e.target.files[0]);
   };
 
-  const handleSubmit = () => {
-    setIsWriting(false);
-    setReviewImage(null);
-    setReviewTitle('');
-    setReviewContent('');
+  const handleSubmit = async () => {
+    if (!reviewTitle.trim() || !reviewContent.trim()) return;
+
+    try {
+      if (mode === 'write') {
+        if (!reviewImage) return;
+        const formData = buildFormData(reviewTitle, reviewContent, reviewImage);
+        const newReview = await createReview({ shopId, formData }).unwrap();
+        setReviews((prev) => [newReview, ...prev]);
+      } else if (mode === 'edit' && editTarget) {
+        const formData = buildFormData(reviewTitle, reviewContent, reviewImage);
+        const updated = await updateReview({
+          shopId,
+          reviewId: editTarget.reviewId,
+          formData,
+        }).unwrap();
+        setReviews((prev) =>
+          prev.map((r) => (r.reviewId === updated.reviewId ? updated : r))
+        );
+      }
+      resetForm();
+      setMode('list');
+    } catch {
+      alert('처리 중 오류가 발생했습니다. 다시 시도해주세요.');
+    }
   };
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setOpenMenuId(null);
-      }
-    };
-
-    if (openMenuId !== null) {
-      document.addEventListener('mousedown', handleClickOutside);
+  const handleDelete = async (reviewId: number) => {
+    try {
+      await deleteReview({ shopId, reviewId }).unwrap();
+      setReviews((prev) => prev.filter((r) => r.reviewId !== reviewId));
+    } catch {
+      alert('삭제 중 오류가 발생했습니다.');
     }
+    setOpenMenuId(null);
+  };
 
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [openMenuId]);
+  const isFormMode = mode === 'write' || mode === 'edit';
+  const isSubmitting = isCreating || isUpdating;
+  const canSubmit =
+    reviewTitle.trim() !== '' &&
+    reviewContent.trim() !== '' &&
+    (mode === 'edit' || reviewImage !== null);
 
   return (
     <div className="flex flex-col">
-      {/* 리뷰 작성하기 / 등록하기 버튼 */}
-      <div className="border-b p-4">
-        <Button
-          label={isWriting ? '리뷰 등록하기' : '리뷰 작성하기'}
-          variant="secondaryDark"
-          size="medium"
-          className="w-full"
-          onClick={isWriting ? handleSubmit : () => setIsWriting(true)}
-        />
+      {/* 액션 버튼 */}
+      <div className="flex gap-2 border-b p-4">
+        {isFormMode ? (
+          <>
+            <Button
+              label="취소"
+              variant="secondaryLight"
+              size="medium"
+              className="flex-1"
+              onClick={handleCancel}
+            />
+            <Button
+              label={mode === 'edit' ? '수정 완료' : '등록하기'}
+              variant="secondaryDark"
+              size="medium"
+              className="flex-1"
+              disabled={!canSubmit || isSubmitting}
+              onClick={handleSubmit}
+            />
+          </>
+        ) : (
+          <Button
+            label="리뷰 작성하기"
+            variant="secondaryDark"
+            size="medium"
+            className="w-full"
+            onClick={handleOpenWrite}
+          />
+        )}
       </div>
 
-      {isWriting ? (
-        <div className="flex flex-col gap-4 px-4 pb-4">
+      {isFormMode ? (
+        <div className="flex flex-col gap-4 p-4">
           {/* 이미지 업로드 */}
           <div
-            onClick={handleImageClick}
+            onClick={() => fileInputRef.current?.click()}
             className="flex aspect-video w-full cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-theme-200"
           >
             {reviewImage ? (
@@ -98,9 +260,18 @@ export const ReviewTab = () => {
                 alt="리뷰 이미지"
                 className="h-full w-full object-cover"
               />
+            ) : mode === 'edit' && editTarget?.imageUrl ? (
+              <img
+                src={editTarget.imageUrl}
+                alt="기존 리뷰 이미지"
+                className="h-full w-full object-cover"
+              />
             ) : (
               <div className="flex flex-col items-center gap-2 text-theme-500">
                 <ImagePlus className="h-8 w-8" />
+                {mode === 'write' && (
+                  <span className="text-xs">이미지를 선택해주세요 (필수)</span>
+                )}
               </div>
             )}
           </div>
@@ -112,7 +283,6 @@ export const ReviewTab = () => {
             onChange={handleImageChange}
           />
 
-          {/* 제목 */}
           <input
             type="text"
             value={reviewTitle}
@@ -121,7 +291,6 @@ export const ReviewTab = () => {
             className="rounded-lg border border-theme-200 px-3 py-2 text-sm text-theme-900 outline-none placeholder:text-theme-300 focus:border-theme-700"
           />
 
-          {/* 내용 */}
           <textarea
             value={reviewContent}
             onChange={(e) => setReviewContent(e.target.value)}
@@ -132,7 +301,7 @@ export const ReviewTab = () => {
         </div>
       ) : (
         <div className="flex flex-col divide-y divide-theme-200">
-          {items.map((review) => (
+          {reviews.map((review) => (
             <div
               key={review.reviewId}
               className="relative flex flex-col gap-3 p-4"
@@ -141,65 +310,82 @@ export const ReviewTab = () => {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <div className="h-8 w-8 overflow-hidden rounded-full bg-theme-200">
-                    {review.profileImageUrl && (
+                    {review.authorProfileUrl && (
                       <img
-                        src={review.profileImageUrl}
-                        alt={review.name}
+                        src={review.authorProfileUrl}
+                        alt={review.authorName}
                         className="h-full w-full object-cover"
                       />
                     )}
                   </div>
                   <p className="text-sm font-medium text-theme-900">
-                    {review.name}
+                    {review.authorName}
                   </p>
                 </div>
 
-                <div
-                  ref={menuRef}
-                  className="relative items-center text-center"
-                >
-                  <button
-                    onMouseDown={(e) => e.stopPropagation()}
-                    onClick={() =>
-                      setOpenMenuId(
-                        openMenuId === review.reviewId ? null : review.reviewId
-                      )
-                    }
-                    className="absolute -right-1 -top-4 text-center text-theme-500 hover:text-theme-900"
-                  >
-                    <MoreVertical className="h-8 w-4" />
-                  </button>
+                {review.owner && (
+                  <div className="relative">
+                    <button
+                      onMouseDown={(e) => e.stopPropagation()}
+                      onClick={() =>
+                        setOpenMenuId(
+                          openMenuId === review.reviewId
+                            ? null
+                            : review.reviewId
+                        )
+                      }
+                      className="absolute -right-1 -top-4 text-theme-500 hover:text-theme-900"
+                    >
+                      <MoreVertical className="h-8 w-4" />
+                    </button>
 
-                  {openMenuId === review.reviewId && (
-                    <div className="absolute right-2 top-6 z-10 flex flex-col overflow-hidden rounded-lg border border-theme-200 bg-white shadow-md">
-                      <button className="w-14 border-b p-2 text-center text-xs text-theme-900 hover:bg-theme-100">
-                        수정
-                      </button>
-                      <button className="w-14 p-2 text-center text-xs text-red-500 hover:bg-theme-100">
-                        삭제
-                      </button>
-                    </div>
-                  )}
-                </div>
+                    {openMenuId === review.reviewId && (
+                      <div
+                        onMouseDown={(e) => e.stopPropagation()}
+                        className="absolute right-2 top-6 z-10 flex flex-col overflow-hidden rounded-lg border border-theme-200 bg-white shadow-md"
+                      >
+                        <button
+                          className="w-14 border-b p-2 text-center text-xs text-theme-900 hover:bg-theme-100"
+                          onClick={() => handleOpenEdit(review)}
+                        >
+                          수정
+                        </button>
+                        <button
+                          className="w-14 p-2 text-center text-xs text-red-500 hover:bg-theme-100"
+                          onClick={() => handleDelete(review.reviewId)}
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
 
-              {/* 내용 */}
+              {/* 제목 */}
+              <p className="text-sm font-semibold text-theme-900">
+                {review.title}
+              </p>
+
+              {/* 내용 + 이미지 */}
               <div className="flex items-start gap-2">
                 <div className="min-w-0 flex-1">
                   <ExpandableText content={review.content} />
                 </div>
-
-                {/* 이미지 */}
-                <div className="h-[120px] w-[120px] shrink-0 overflow-hidden rounded bg-theme-200">
-                  {review.imageUrl && (
+                {review.imageUrl && (
+                  <div className="h-[120px] w-[120px] shrink-0 overflow-hidden rounded bg-theme-200">
                     <img
                       src={review.imageUrl}
                       alt="리뷰 이미지"
                       className="h-full w-full object-cover"
                     />
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
+
+              <p className="text-right text-xs text-theme-500">
+                {formatDate(review.createdAt)}
+              </p>
             </div>
           ))}
 
@@ -207,8 +393,13 @@ export const ReviewTab = () => {
             {isLoading && (
               <p className="text-sm text-theme-300">불러오는 중...</p>
             )}
-            {!hasMore && (
+            {!hasMore && reviews.length > 0 && (
               <p className="text-sm text-theme-300">마지막 리뷰입니다.</p>
+            )}
+            {!isLoading && reviews.length === 0 && (
+              <p className="py-6 text-center text-xs text-theme-300">
+                등록된 리뷰가 없습니다.
+              </p>
             )}
           </div>
         </div>

--- a/src/features/map/index.ts
+++ b/src/features/map/index.ts
@@ -8,3 +8,4 @@ export {
 export { oneDayClassApi } from './api/one-day-class-api';
 export { mapStoryApi } from './api/map-story-api';
 export { favoriteApi } from './api/favorite-api';
+export { reviewApi } from './api/review-api';

--- a/src/features/map/types/review-types.ts
+++ b/src/features/map/types/review-types.ts
@@ -1,0 +1,18 @@
+export interface ShopReviewItem {
+  reviewId: number;
+  userId: number;
+  authorName: string;
+  authorProfileUrl: string | null;
+  title: string;
+  content: string;
+  imageUrl: string | null;
+  owner: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ShopReviewListResponse {
+  items: ShopReviewItem[];
+  nextCursorId: number | null;
+  hasNext: boolean;
+}


### PR DESCRIPTION
* 커서 기반 무한 스크롤
  - 기존 페이지 기반 `useInfiniteScroll`과 달리 `cursorId` + `hasNext` 방식으로 동작
  - 클로저 stale 방지를 위해 커서·로딩 상태를 `useRef`로 관리
  - `shopId` 변경 시 목록·커서 초기화 후 첫 페이지 재조회

* Multipart 폼 데이터 전송
  - `request` 파트는 `application/json` Blob으로, `image` 파트는 File로 구성
  - 작성 시 이미지 필수 / 수정 시 이미지 선택 (기존 이미지 유지)

* owner 기반 수정·삭제 제어
  - `owner: true`인 리뷰에만 수정·삭제 메뉴 노출
  - 수정·삭제 후 서버 재조회 없이 로컬 상태 즉시 반영