### PR TITLE
feat: 채팅방 생성 API 연동 및 유저 검색 엔드포인트 교체, 채팅 관련 버그 수정 및 UserSelectModal 분리 

### DIFF
--- a/src/features/chat/api/chat-api.ts
+++ b/src/features/chat/api/chat-api.ts
@@ -10,9 +10,19 @@ import type {
   GetLatestMessagesParams,
   GetMessagesBeforeParams,
   MessageSyncResponse,
+  SearchChatUsersParams,
   SyncMessagesParams,
   UserListItem,
 } from '../types/chat-types';
+
+interface PageResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+  last: boolean;
+}
 
 export const chatApi = createApi({
   reducerPath: 'chatApi',
@@ -21,14 +31,22 @@ export const chatApi = createApi({
   endpoints: (builder) => ({
     // ===== 채팅방 =====
 
-    // 유저 검색 — 새 메시지 시작 시 대화 상대 검색에 사용
-    getUserList: builder.query<UserListItem[], string | void>({
-      query: (search = '') =>
-        search
-          ? `${CHAT_ENDPOINTS.USER_LIST}?search=${search}`
-          : CHAT_ENDPOINTS.USER_LIST,
-      transformResponse: (response: ApiResponse<UserListItem[]>) =>
-        response.data,
+    // 새 메시지 시작 시 대화 상대 검색에 사용
+    searchChatUsers: builder.query<
+      UserListItem[],
+      SearchChatUsersParams | void
+    >({
+      query: (params = {}) => {
+        const { keyword = '', page = 0, size = 20 } = params ?? {};
+        const searchParams = new URLSearchParams({
+          page: String(page),
+          size: String(size),
+        });
+        if (keyword) searchParams.set('keyword', keyword);
+        return `${CHAT_ENDPOINTS.USER_SEARCH}?${searchParams.toString()}`;
+      },
+      transformResponse: (response: ApiResponse<PageResponse<UserListItem>>) =>
+        response.data.content,
     }),
 
     // 내가 참여한 채팅방 목록 전체 조회
@@ -140,7 +158,7 @@ export const chatApi = createApi({
 });
 
 export const {
-  useGetUserListQuery,
+  useSearchChatUsersQuery,
   useGetChatRoomsQuery,
   useCreateChatRoomMutation,
   useGetOrCreateDirectChatMutation,

--- a/src/features/chat/components/chat-list.tsx
+++ b/src/features/chat/components/chat-list.tsx
@@ -9,9 +9,8 @@ import {
 } from '../slices/chat-slice';
 import type { ChatRoomListProps } from '../types/chat-types';
 import { ChatListItem } from './chat-list-item';
-import { UserSelectModal } from '../../../shared/components/common/user-select-modal';
+import { ChatUserSelectModal } from './chat-user-select-modal';
 
-// isLoading / error / chatRooms 빈 상태를 early return으로 처리
 const ChatRoomList = ({
   isLoading,
   error,
@@ -158,7 +157,9 @@ export const ChatList = () => {
       </div>
 
       {/* 새 메시지 유저 검색 모달 */}
-      {isModalOpen && <UserSelectModal onClose={() => setIsModalOpen(false)} />}
+      {isModalOpen && (
+        <ChatUserSelectModal onClose={() => setIsModalOpen(false)} />
+      )}
     </div>
   );
 };

--- a/src/features/chat/components/chat-room.tsx
+++ b/src/features/chat/components/chat-room.tsx
@@ -44,7 +44,7 @@ export const ChatRoom = () => {
   // 초기 메시지 로드 — 채팅방 진입 시 최신 메시지 50개를 API로 조회
   const { data: latestMessages } = useGetLatestMessagesQuery(
     { roomId: selectedChatRoomId!, limit: 50 },
-    { skip: !selectedChatRoomId }
+    { skip: !selectedChatRoomId, refetchOnMountOrArgChange: true }
   );
 
   useEffect(() => {

--- a/src/features/chat/components/chat-user-select-modal.tsx
+++ b/src/features/chat/components/chat-user-select-modal.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useState } from 'react';
+
+import { useAppDispatch } from '../../../app/hooks';
+import {
+  useSearchChatUsersQuery,
+  useGetOrCreateDirectChatMutation,
+} from '../api/chat-api';
+import { selectChatRoom } from '../slices/chat-slice';
+import type { UserListItem, UserSelectModalProps } from '../types/chat-types';
+import { SPECIALTY_LABEL } from '../../artist/outbound-management/constants/outbound-management-constants';
+
+interface UserListProps {
+  isLoading: boolean;
+  userList: UserListItem[];
+  selectedUserId: number | null;
+  onSelect: (userId: number) => void;
+}
+
+const UserList = ({
+  isLoading,
+  userList,
+  selectedUserId,
+  onSelect,
+}: UserListProps) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-theme-900" />
+      </div>
+    );
+  }
+
+  if (userList.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-theme-500">
+        검색 결과가 없습니다.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      {userList.map((user) => (
+        <div
+          key={user.userId}
+          onClick={() => onSelect(user.userId)}
+          className={`grid cursor-pointer grid-cols-3 border-b border-gray-100 py-3 transition-colors hover:bg-gray-50 ${
+            selectedUserId === user.userId ? 'bg-gray-100' : ''
+          }`}
+        >
+          <span className="text-center text-sm text-gray-900">
+            {user.accountName}
+          </span>
+          <span className="text-center text-sm text-gray-600">
+            {user.specialty ? SPECIALTY_LABEL[user.specialty] : '-'}
+          </span>
+          <span className="text-center text-sm text-gray-600">
+            {user.statusLabel}
+          </span>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export const ChatUserSelectModal = ({ onClose }: UserSelectModalProps) => {
+  const dispatch = useAppDispatch();
+  const [search, setSearch] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+
+  const { data: userList = [], isLoading } = useSearchChatUsersQuery({
+    keyword: search,
+    page: 0,
+    size: 20,
+  });
+
+  const [getOrCreateDirectChat, { isLoading: isCreating }] =
+    useGetOrCreateDirectChatMutation();
+
+  const handleSend = useCallback(async () => {
+    if (!selectedUserId) return;
+    try {
+      const chatRoom = await getOrCreateDirectChat(selectedUserId).unwrap();
+      dispatch(selectChatRoom(chatRoom.roomId));
+      onClose();
+    } catch (e) {
+      console.error('채팅방 생성 실패:', e);
+    }
+  }, [selectedUserId, getOrCreateDirectChat, dispatch, onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-[500px] rounded-2xl bg-white p-8"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-6 text-center text-xl font-bold">사용자 계정 검색</h2>
+
+        <div className="relative mb-4">
+          <svg
+            className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            type="text"
+            placeholder="검색"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full rounded-lg border border-gray-200 py-2 pl-10 pr-4 text-sm focus:border-gray-400 focus:outline-none"
+          />
+        </div>
+
+        <div className="grid grid-cols-3 border-b border-gray-200 pb-4 text-center">
+          <span className="text-sm font-semibold text-gray-900">계정명</span>
+          <span className="text-sm font-semibold text-gray-900">
+            주요 카테고리
+          </span>
+          <span className="text-sm font-semibold text-gray-900">계약 상태</span>
+        </div>
+
+        <div className="mb-6 max-h-80 overflow-y-auto">
+          <UserList
+            isLoading={isLoading}
+            userList={userList}
+            selectedUserId={selectedUserId}
+            onSelect={setSelectedUserId}
+          />
+        </div>
+
+        <button
+          onClick={handleSend}
+          disabled={!selectedUserId || isCreating}
+          className="w-full rounded-lg bg-black py-3 font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isCreating ? '생성 중...' : '보내기'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/chat/components/message-list.tsx
+++ b/src/features/chat/components/message-list.tsx
@@ -20,6 +20,8 @@ export const MessageList = () => {
   const isLoadingMoreRef = useRef(false); // 이전 메시지 로딩 중 여부
   const isInitialLoadRef = useRef(true); // 최초 진입 여부 — 첫 로드 시 스크롤을 최하단으로 즉시 이동
   const isAtBottomLocalRef = useRef(true); // 현재 스크롤이 최하단인지 여부
+  // 이전 메시지 수 — bulk 교체(setMessages)와 단일 추가(addMessage)를 구분하기 위해 사용
+  const prevMessageCountRef = useRef(0);
 
   const [oldestMessageId, setOldestMessageId] = useState<number | null>(null);
   const [hasMore, setHasMore] = useState(true); // 더 불러올 과거 메시지가 있는지
@@ -50,21 +52,23 @@ export const MessageList = () => {
     setIsAtBottomLocal(true);
     isLoadingMoreRef.current = false;
     isInitialLoadRef.current = true;
+    prevMessageCountRef.current = 0;
   }, [selectedChatRoomId]);
 
   // 메시지 변경 시 스크롤 처리
   useEffect(() => {
     if (currentMessages.length === 0) return;
 
-    // 최초 진입: 스크롤을 즉시 최하단으로 이동
+    // Case 1: 최초 진입 / 재진입 — 즉시 최하단으로 이동
     if (isInitialLoadRef.current) {
       messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
       setOldestMessageId(currentMessages[0].id);
       isInitialLoadRef.current = false;
+      prevMessageCountRef.current = currentMessages.length;
       return;
     }
 
-    // 이전 메시지(50개 이상인 경우) 로드 완료: 스크롤 위치 복원 (위로 스크롤되지 않도록)
+    // Case 2: 이전 메시지 로드 완료 — 스크롤 위치 복원
     if (isLoadingMoreRef.current) {
       const container = containerRef.current;
       if (container) {
@@ -72,13 +76,28 @@ export const MessageList = () => {
           container.scrollHeight - prevScrollHeightRef.current;
       }
       isLoadingMoreRef.current = false;
+      prevMessageCountRef.current = currentMessages.length;
       return;
     }
 
-    // 새 메시지 수신: 최하단에 있을 때만 자동으로 최하단으로 스크롤
+    // Case 3: 메시지 업데이트
+    // - 정확히 +1 증가: WebSocket 단일 메시지 수신 → smooth 스크롤 (자연스러운 알림 효과)
+    // - 그 외 (setMessages bulk 교체, refetch 등): auto 스크롤
+    //   → refetchOnMountOrArgChange로 인한 2차 setMessages 호출 시 top→bottom smooth 방지
     if (isAtBottomLocalRef.current) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      const isExactlyOneNewMessage =
+        currentMessages.length === prevMessageCountRef.current + 1;
+      messagesEndRef.current?.scrollIntoView({
+        behavior: isExactlyOneNewMessage ? 'smooth' : 'auto',
+      });
     }
+
+    // refetch로 메시지가 교체될 경우 oldest ID를 실제 메시지 기준으로 동기화
+    // 동일한 ID면 React가 re-render를 bail out하므로 부담 없음
+    if (currentMessages.length > 0) {
+      setOldestMessageId(currentMessages[0].id);
+    }
+    prevMessageCountRef.current = currentMessages.length;
   }, [currentMessages]);
 
   const { data: olderMessages } = useGetMessagesBeforeQuery(
@@ -134,7 +153,7 @@ export const MessageList = () => {
 
     // 최상단 도달 시 이전 메시지 로드 트리거
     if (!hasMore || isLoadingMoreRef.current || !oldestMessageId) return;
-    if (container.scrollTop === 0) {
+    if (container.scrollTop < 5) {
       prevScrollHeightRef.current = container.scrollHeight; // 현재 높이 저장
       isLoadingMoreRef.current = true;
       setBeforeMessageId(oldestMessageId);

--- a/src/features/chat/constants/chat-constants.ts
+++ b/src/features/chat/constants/chat-constants.ts
@@ -18,6 +18,6 @@ export const CHAT_ENDPOINTS = {
   // 이미지 업로드
   UPLOAD_IMAGE: '/api/chat/upload/image',
 
-  // 유저 검색
-  USER_LIST: '/api/users/list',
+  // 채팅 상대 검색
+  USER_SEARCH: '/api/chat/users/search',
 } as const;

--- a/src/features/chat/pages/chat.tsx
+++ b/src/features/chat/pages/chat.tsx
@@ -1,4 +1,6 @@
-import { useAppSelector } from '../../../app/hooks';
+import { useEffect } from 'react';
+
+import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 
 import { ChatWebSocketProvider } from '../hooks/chat-websocket-provider';
 import { useChatWebSocketContext } from '../hooks/use-chat-websocket-context';
@@ -6,10 +8,16 @@ import { useChatWebSocketContext } from '../hooks/use-chat-websocket-context';
 import { ChatList } from '../components/chat-list';
 import { ChatRoom } from '../components/chat-room';
 import { EmptyChat } from '../components/empty-chat';
+import { selectChatRoom } from '../slices/chat-slice';
 
 const ChatPageInner = () => {
+  const dispatch = useAppDispatch();
   const { selectedChatRoomId } = useAppSelector((state) => state.chat);
   const { isConnected } = useChatWebSocketContext();
+
+  useEffect(() => {
+    dispatch(selectChatRoom(null));
+  }, [dispatch]);
 
   return (
     <div className="flex h-[52.2rem] flex-1 gap-3 overflow-hidden bg-gray-100">

--- a/src/features/chat/types/chat-types.ts
+++ b/src/features/chat/types/chat-types.ts
@@ -1,5 +1,7 @@
 import type { useChatWebSocket } from '../hooks/use-chat-websocket';
 
+import type { UserRole } from '../../../shared/constants';
+
 export type MessageType = 'TEXT' | 'IMAGE' | 'FILE' | 'SYSTEM';
 export type ChatRoomType = 'ONE_TO_ONE' | 'GROUP';
 
@@ -23,6 +25,15 @@ export interface UserListProps {
   userList: UserListItem[];
   selectedUserId: number | null;
   onSelect: (userId: number) => void;
+}
+
+export interface UserListItem {
+  userId: number;
+  accountName: string;
+  role: UserRole;
+  profileImageUrl: string | null;
+  specialty: string | null;
+  statusLabel: string;
 }
 
 export interface MessageItemProps {
@@ -62,11 +73,10 @@ export interface GetMessagesBeforeParams {
   limit?: number;
 }
 
-export interface UserListItem {
-  userId: number;
-  name: string;
-  category: string;
-  status: string;
+export interface SearchChatUsersParams {
+  keyword?: string;
+  page?: number;
+  size?: number;
 }
 
 export interface Participant {

--- a/src/features/contract-management/pages/contract-management.tsx
+++ b/src/features/contract-management/pages/contract-management.tsx
@@ -286,7 +286,6 @@ export const ContractManagement = () => {
     <div className="flex h-full gap-4">
       {showArtistModal && (
         <UserSelectModal
-          mode="contract"
           onClose={() => setShowArtistModal(false)}
           onSelectArtist={(artist) => {
             setSelectedArtist(artist);

--- a/src/shared/components/common/user-select-modal.tsx
+++ b/src/shared/components/common/user-select-modal.tsx
@@ -1,125 +1,37 @@
 import { useCallback, useState } from 'react';
 
-import { useAppDispatch, useAppSelector } from '../../../app/hooks';
-
-import {
-  useGetUserListQuery,
-  useGetOrCreateDirectChatMutation,
-} from '../../../features/chat/api/chat-api';
-import { selectChatRoom } from '../../../features/chat/slices/chat-slice';
+import { useAppSelector } from '../../../app/hooks';
 import { useSearchArtistsQuery } from '../../../features/contract-management/api/contract-management-api';
 import type { ArtistSearchItem } from '../../../features/contract-management/types/contract-management-types';
-import type {
-  UserListProps,
-  UserSelectModalProps,
-} from '../../../features/chat/types/chat-types';
 
-type Mode = 'chat' | 'contract';
-
-interface ExtendedUserSelectModalProps extends UserSelectModalProps {
-  mode?: Mode;
-  onSelectArtist?: (artist: ArtistSearchItem) => void;
+export interface ArtistSelectModalProps {
+  onClose: () => void;
+  onSelectArtist: (artist: ArtistSearchItem) => void;
 }
-
-const UserList = ({
-  isLoading,
-  userList,
-  selectedUserId,
-  onSelect,
-}: UserListProps) => {
-  if (isLoading) {
-    return (
-      <div className="flex justify-center py-8">
-        <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-theme-900" />
-      </div>
-    );
-  }
-
-  if (userList.length === 0) {
-    return (
-      <p className="py-8 text-center text-sm text-theme-500">
-        검색 결과가 없습니다.
-      </p>
-    );
-  }
-
-  return (
-    <>
-      {userList.map((user) => (
-        <div
-          key={user.userId}
-          onClick={() => onSelect(user.userId)}
-          className={`grid cursor-pointer grid-cols-3 border-b border-gray-100 py-3 transition-colors hover:bg-gray-50 ${
-            selectedUserId === user.userId ? 'bg-gray-100' : ''
-          }`}
-        >
-          <span className="text-sm text-gray-900">{user.name}</span>
-          <span className="text-sm text-gray-600">{user.category}</span>
-          <span className="text-sm text-gray-600">{user.status}</span>
-        </div>
-      ))}
-    </>
-  );
-};
 
 export const UserSelectModal = ({
   onClose,
-  mode = 'chat',
   onSelectArtist,
-}: ExtendedUserSelectModalProps) => {
-  const dispatch = useAppDispatch();
+}: ArtistSelectModalProps) => {
   const userId = useAppSelector((state) => state.auth.user?.userId);
   const [search, setSearch] = useState('');
-  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
   const [selectedArtistId, setSelectedArtistId] = useState<number | null>(null);
 
-  const { data: userList = [], isLoading: isChatLoading } = useGetUserListQuery(
-    search,
-    { skip: mode !== 'chat' }
+  const { data: artistData, isLoading } = useSearchArtistsQuery(
+    { userId: userId!, keyword: search },
+    { skip: !userId || search.length < 1 }
   );
-
-  const { data: artistData, isLoading: isArtistLoading } =
-    useSearchArtistsQuery(
-      { userId: userId!, keyword: search },
-      { skip: mode !== 'contract' || !userId || search.length < 1 }
-    );
-
+  console.log(artistData, isLoading);
   const artistList = artistData?.items ?? [];
-  const isLoading = mode === 'chat' ? isChatLoading : isArtistLoading;
 
-  const [getOrCreateDirectChat, { isLoading: isCreating }] =
-    useGetOrCreateDirectChatMutation();
-
-  const handleSend = useCallback(async () => {
-    if (mode === 'chat') {
-      if (!selectedUserId) return;
-      try {
-        const chatRoom = await getOrCreateDirectChat(selectedUserId).unwrap();
-        dispatch(selectChatRoom(chatRoom.roomId));
-        onClose();
-      } catch (e) {
-        console.error('채팅방 생성 실패:', e);
-      }
-    } else {
-      if (!selectedArtistId) return;
-      const artist = artistList.find((a) => a.artistId === selectedArtistId);
-      if (artist && onSelectArtist) {
-        onSelectArtist(artist);
-        onClose();
-      }
+  const handleSelect = useCallback(() => {
+    if (!selectedArtistId) return;
+    const artist = artistList.find((a) => a.artistId === selectedArtistId);
+    if (artist) {
+      onSelectArtist(artist);
+      onClose();
     }
-  }, [
-    mode,
-    selectedUserId,
-    selectedArtistId,
-    artistList,
-    getOrCreateDirectChat,
-    dispatch,
-    onClose,
-    onSelectArtist,
-  ]);
-
-  const isDisabled = mode === 'chat' ? !selectedUserId : !selectedArtistId;
+  }, [selectedArtistId, artistList, onSelectArtist, onClose]);
 
   return (
     <div
@@ -130,9 +42,7 @@ export const UserSelectModal = ({
         className="w-[500px] rounded-2xl bg-white p-8"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="mb-6 text-center text-xl font-bold">
-          {mode === 'chat' ? '사용자 계정 검색' : '작가 검색'}
-        </h2>
+        <h2 className="mb-6 text-center text-xl font-bold">작가 검색</h2>
 
         <div className="relative mb-4">
           <svg
@@ -158,26 +68,13 @@ export const UserSelectModal = ({
         </div>
 
         <div className="grid grid-cols-3 border-b border-gray-200 pb-4 text-center">
-          <span className="text-sm font-semibold text-gray-900">
-            {mode === 'chat' ? '계정명' : '작가명'}
-          </span>
-          <span className="text-sm font-semibold text-gray-900">
-            {mode === 'chat' ? '주요 카테고리' : '전문분야'}
-          </span>
-          <span className="text-sm font-semibold text-gray-900">
-            {mode === 'chat' ? '상태' : '이메일'}
-          </span>
+          <span className="text-sm font-semibold text-gray-900">작가명</span>
+          <span className="text-sm font-semibold text-gray-900">전문분야</span>
+          <span className="text-sm font-semibold text-gray-900">이메일</span>
         </div>
 
         <div className="mb-6 max-h-80 overflow-y-auto">
-          {mode === 'chat' ? (
-            <UserList
-              isLoading={isLoading}
-              userList={userList}
-              selectedUserId={selectedUserId}
-              onSelect={setSelectedUserId}
-            />
-          ) : isLoading ? (
+          {isLoading ? (
             <div className="flex justify-center py-8">
               <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-theme-900" />
             </div>
@@ -209,11 +106,11 @@ export const UserSelectModal = ({
         </div>
 
         <button
-          onClick={handleSend}
-          disabled={isDisabled || isCreating}
+          onClick={handleSelect}
+          disabled={!selectedArtistId}
           className="w-full rounded-lg bg-black py-3 font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {isCreating ? '생성 중...' : mode === 'chat' ? '보내기' : '선택'}
+          선택
         </button>
       </div>
     </div>


### PR DESCRIPTION
* 채팅방 생성 (새 메시지 버튼)
  - `GET /api/chat/users/search` 연동으로 채팅 상대 검색 구현
  - 유저 선택 후 `POST /api/chat/rooms/direct/{partnerId}` 호출,
  기존 방이 있으면 재사용하고 없으면 새로 생성
  - 검색 결과 컬럼: 계정명 / 주요 카테고리 / 계약 상태(ARTIST 기준)

* UserSelectModal 분리
  - 채팅/계약 두 가지 용도를 `mode` prop으로 처리하던 단일 파일을 분리
  - `ChatUserSelectModal` → `features/chat/components/`
  - `UserSelectModal` (계약 전용) → `shared/components/common/` 유지

### 🐛 버그 수정

* 채팅방 전환 시 메시지 미갱신
  - 원인: RTK Query 캐시로 인해 이전 방에서 받은 데이터를 그대로 사용
  - 수정: `useGetLatestMessagesQuery`에 `refetchOnMountOrArgChange: true` 추가

* 채팅방 진입 시 smooth 스크롤 오작동
  - 원인: `refetchOnMountOrArgChange`로 인한 2차 `setMessages` 호출이
    `isInitialLoadRef`가 이미 `false`인 상태에서 실행되어
    `isAtBottomLocalRef`가 stale `true`인 채로 smooth 스크롤 발동,
    메시지가 많은 경우 top → bottom으로 긴 애니메이션 발생
  - 수정: `prevMessageCountRef`를 추가해 메시지 수가 정확히 +1인 경우
    (WebSocket 단일 수신)만 smooth, 그 외 bulk 교체는 auto로 처리

* 앞의 문제 해결 과정에서 이전 메시지 무한 스크롤 미작동
  - 원인 1: `scrollTop === 0` 조건이 브라우저 서브픽셀 렌더링으로
    인해 정확히 0에 도달하지 못하는 경우 트리거 안 됨
  - 원인 2: refetch로 메시지가 교체될 때 `oldestMessageId`가 동기화되지
    않아 잘못된 ID로 이전 메시지 요청
  - 수정: 임계값 `< 5`로 완화, Case 3에서 `oldestMessageId` 동기화 추가

* 채팅 페이지 재진입 시 이전 채팅방 유지
  - 원인: `selectedChatRoomId`가 Redux에 남아있어 재진입 시 그대로 복원
  - 수정: `ChatPageInner` 마운트 시 `selectChatRoom(null)` 디스패치
