### PR TITLE
feat: home-page에 들어갈 carousel-banner 컴포넌트 추가

### DIFF
--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -4,6 +4,7 @@ import { ChevronRight, ChevronLeft } from 'lucide-react';
 
 import { useAppSelector } from '../../app/hooks';
 import { Button } from '../../shared/components/ui';
+import { CarouselBanner } from '../../shared/components/common/carousel-banner';
 import { API_BASE_URL, ROUTES } from '../../shared/constants';
 
 import { useGetNoticesQuery } from '../../features/notice/api/notice-api';
@@ -52,8 +53,9 @@ export const HomePage = () => {
   return (
     <div className="flex flex-col gap-3 lg:flex-row">
       <div className="flex flex-1 flex-col gap-3">
-        <section className="flex h-[20.93rem] w-full items-center justify-center rounded-sm border border-gray-300">
-          <h2>캐러셀 배너</h2>
+        <section className="h-[20.93rem] w-full overflow-hidden rounded-sm">
+          <h2 className="sr-only">캐러셀 배너</h2>
+          <CarouselBanner />
         </section>
 
         <section className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">

--- a/src/shared/components/common/carousel-banner.tsx
+++ b/src/shared/components/common/carousel-banner.tsx
@@ -1,0 +1,96 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+const CAROUSEL_SLIDES = [
+  { id: 1, imageUrl: '', alt: '배너 1', bgColor: 'bg-gray-200' },
+  { id: 2, imageUrl: '', alt: '배너 2', bgColor: 'bg-gray-300' },
+  { id: 3, imageUrl: '', alt: '배너 3', bgColor: 'bg-blue-200' },
+  { id: 4, imageUrl: '', alt: '배너 4', bgColor: 'bg-green-200' },
+  { id: 5, imageUrl: '', alt: '배너 5', bgColor: 'bg-yellow-100' },
+];
+
+const AUTO_SLIDE_INTERVAL = 5000;
+
+export const CarouselBanner = () => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const totalSlides = CAROUSEL_SLIDES.length;
+
+  const goToSlide = useCallback((index: number) => {
+    setCurrentIndex(index);
+  }, []);
+
+  const goToPrev = useCallback(() => {
+    setCurrentIndex((prev) => (prev - 1 + totalSlides) % totalSlides);
+  }, [totalSlides]);
+
+  const goToNext = useCallback(() => {
+    setCurrentIndex((prev) => (prev + 1) % totalSlides);
+  }, [totalSlides]);
+
+  // 자동 슬라이드
+  useEffect(() => {
+    const interval = setInterval(goToNext, AUTO_SLIDE_INTERVAL);
+    return () => clearInterval(interval);
+  }, [goToNext]);
+
+  return (
+    <div className="relative h-full w-full overflow-hidden">
+      {/* 슬라이드 트랙 */}
+      <div
+        className="flex h-full transition-transform duration-300 ease-in-out"
+        style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+      >
+        {CAROUSEL_SLIDES.map((slide) => (
+          <div
+            key={slide.id}
+            className={`relative h-full min-w-full ${slide.bgColor} flex items-center justify-center`}
+          >
+            {slide.imageUrl ? (
+              <img
+                src={slide.imageUrl}
+                alt={slide.alt}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <span className="text-sm text-gray-400">{slide.alt}</span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* 이전 버튼 */}
+      <button
+        onClick={goToPrev}
+        aria-label="이전 슬라이드"
+        className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-black/20 p-2 transition-all duration-200 hover:bg-black/40"
+      >
+        <ChevronLeft className="h-5 w-5 text-white" />
+      </button>
+
+      {/* 다음 버튼 */}
+      <button
+        onClick={goToNext}
+        aria-label="다음 슬라이드"
+        className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-black/20 p-2 transition-all duration-200 hover:bg-black/40"
+      >
+        <ChevronRight className="h-5 w-5 text-white" />
+      </button>
+
+      {/* 인디케이터 */}
+      <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-2">
+        {CAROUSEL_SLIDES.map((_, index) => (
+          <button
+            key={index}
+            onClick={() => goToSlide(index)}
+            aria-label={`슬라이드 ${index + 1}로 이동`}
+            className={`rounded-full bg-white transition-all duration-300 ${
+              index === currentIndex
+                ? 'h-3 w-3 opacity-100'
+                : 'h-2 w-2 opacity-50 hover:opacity-80'
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
* home-page에 carousel-banner 컴포넌트 추가(/share/components/common/carousel-banner.tsx)
  - 슬라이드 이동
  - 이전/다음 버튼 클릭
  - 인디케이터현재 슬라이드 강조(크기 차이) + 클릭 이동
  - 자동 슬라이드5초마다 자동 전환, 컴포넌트 언마운트 시 clearInterval이미지 교체
  - CAROUSEL_SLIDES 배열의 imageUrl만 수정이미지 없을 때bgColor 폴백 배경으로 표시