### PR TITLE
feat: chat-list.tsx 검색 기능 추가

### DIFF
--- a/src/features/chat/components/chat-list.tsx
+++ b/src/features/chat/components/chat-list.tsx
@@ -66,6 +66,7 @@ export const ChatList = () => {
   );
   const { data, isLoading, error } = useGetChatRoomsQuery();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
 
   // 채팅방 목록 로드 완료 시 Redux에 저장 + 파트너 읽음 시각 초기화
   useEffect(() => {
@@ -92,6 +93,15 @@ export const ChatList = () => {
     (roomId: string) => dispatch(selectChatRoom(roomId)),
     [dispatch]
   );
+
+  // 검색어로 파트너 이름 필터링
+  const filteredChatRooms = searchQuery.trim()
+    ? chatRooms.filter((room) =>
+        room.partnerName
+          .toLowerCase()
+          .includes(searchQuery.trim().toLowerCase())
+      )
+    : chatRooms;
 
   return (
     <div className="flex h-full flex-col rounded-xl bg-white">
@@ -127,6 +137,8 @@ export const ChatList = () => {
           <input
             type="text"
             placeholder="검색"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
             className="w-full rounded-lg border border-gray-200 py-2 pl-10 pr-4 text-sm focus:border-gray-400 focus:outline-none"
           />
           <svg
@@ -150,7 +162,7 @@ export const ChatList = () => {
         <ChatRoomList
           isLoading={isLoading}
           error={error}
-          chatRooms={chatRooms}
+          chatRooms={filteredChatRooms}
           selectedChatRoomId={selectedChatRoomId}
           onSelectRoom={handleSelectRoom}
         />


### PR DESCRIPTION
* chat-list.tsx 검색기능 추가
  - `searchQuery` 상태 추가 및 검색 input에 `value` / `onChange` 연결
  - 검색어 입력 시 `partnerName` 기준으로 즉시 필터링 (대소문자 무시)
  - 검색어가 없으면 원본 배열을 그대로 참조해 불필요한 연산 없음
  - 검색 결과가 없을 경우 기존 빈 상태 UI("대화중인 상대방이 없습니다.") 재사용

### 구현 방식
서버 요청 없이 Redux에 저장된 `chatRooms`를 클라이언트에서 필터링하는 방식으로,
이미 목록 전체를 로드한 상태에서 동작하므로 추가 API 호출이 발생하지 않습니다.