### PR TITLE
Feature/layout - 전체 레이아웃 스크롤 구조 개선 및 UX 정비

### DIFF
--- a/src/features/chat/components/message-list.tsx
+++ b/src/features/chat/components/message-list.tsx
@@ -15,7 +15,6 @@ export const MessageList = () => {
     useAppSelector((state) => state.chat);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null); // 스크롤 최하단 앵커
   const prevScrollHeightRef = useRef<number>(0); // 이전 메시지 로드 후 스크롤 위치 복원에 사용
   const isLoadingMoreRef = useRef(false); // 이전 메시지 로딩 중 여부
   const isInitialLoadRef = useRef(true); // 최초 진입 여부 — 첫 로드 시 스크롤을 최하단으로 즉시 이동
@@ -61,7 +60,10 @@ export const MessageList = () => {
 
     // Case 1: 최초 진입 / 재진입 — 즉시 최하단으로 이동
     if (isInitialLoadRef.current) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
+      if (containerRef.current) {
+        containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      }
+
       setOldestMessageId(currentMessages[0].id);
       isInitialLoadRef.current = false;
       prevMessageCountRef.current = currentMessages.length;
@@ -87,9 +89,12 @@ export const MessageList = () => {
     if (isAtBottomLocalRef.current) {
       const isExactlyOneNewMessage =
         currentMessages.length === prevMessageCountRef.current + 1;
-      messagesEndRef.current?.scrollIntoView({
-        behavior: isExactlyOneNewMessage ? 'smooth' : 'auto',
-      });
+      if (containerRef.current) {
+        containerRef.current.scrollTo({
+          top: containerRef.current.scrollHeight,
+          behavior: isExactlyOneNewMessage ? 'smooth' : 'auto',
+        });
+      }
     }
 
     // refetch로 메시지가 교체될 경우 oldest ID를 실제 메시지 기준으로 동기화
@@ -128,7 +133,10 @@ export const MessageList = () => {
 
   const scrollToBottom = useCallback(
     (behavior: 'smooth' | 'auto' = 'smooth') => {
-      messagesEndRef.current?.scrollIntoView({ behavior });
+      containerRef.current?.scrollTo({
+        top: containerRef.current.scrollHeight,
+        behavior,
+      });
     },
     []
   );
@@ -188,7 +196,7 @@ export const MessageList = () => {
     <div
       ref={containerRef}
       onScroll={handleScroll}
-      className="flex-1 overflow-y-auto bg-white px-6"
+      className="flex-1 overflow-y-auto overscroll-contain bg-white px-6"
     >
       {!hasMore && currentMessages.length > 0 && (
         <div className="py-2 text-center text-xs text-theme-900">
@@ -217,8 +225,6 @@ export const MessageList = () => {
             {partnerName}님이 메세지를 입력하고 있습니다.
           </div>
         ))}
-
-      <div ref={messagesEndRef} />
     </div>
   );
 };

--- a/src/features/my-page/components/my-favorites.tsx
+++ b/src/features/my-page/components/my-favorites.tsx
@@ -29,9 +29,7 @@ export const MyFavorites = () => {
 
   return (
     <MyPageLayout>
-      <div className="max-h-[69.5625rem] overflow-y-auto [&::-webkit-scrollbar-thumb]:bg-black [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:w-[5px]">
-        <MyFavoritesGrid fetchData={fetchData} onShopClick={handleShopClick} />
-      </div>
+      <MyFavoritesGrid fetchData={fetchData} onShopClick={handleShopClick} />
     </MyPageLayout>
   );
 };

--- a/src/features/my-page/components/my-posts.tsx
+++ b/src/features/my-page/components/my-posts.tsx
@@ -38,9 +38,7 @@ export const MyPosts = () => {
 
   return (
     <MyPageLayout>
-      <div className="max-h-[69.5625rem] overflow-y-auto [&::-webkit-scrollbar-thumb]:bg-black [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:w-[5px]">
-        <MyPostsGrid fetchData={fetchData} onPostClick={handlePostClick} />
-      </div>
+      <MyPostsGrid fetchData={fetchData} onPostClick={handlePostClick} />
     </MyPageLayout>
   );
 };

--- a/src/features/post/components/post-grid.tsx
+++ b/src/features/post/components/post-grid.tsx
@@ -26,7 +26,7 @@ export const PostGrid = ({ fetchData, onPostClick }: PostGridProps) => {
   }
 
   return (
-    <div className="aspect-square w-full overflow-y-auto">
+    <div className="w-full">
       <div className="grid grid-cols-3 gap-1">
         {posts.map((post) => (
           <button

--- a/src/features/shop/shop-management/pages/shop-management.tsx
+++ b/src/features/shop/shop-management/pages/shop-management.tsx
@@ -180,7 +180,7 @@ export const ShopManagement = () => {
   const isFormDisabled = mode === 'default' || mode === 'selected';
 
   return (
-    <div className="grid w-full flex-1 grid-cols-2 gap-3 overflow-y-auto bg-gray-100">
+    <div className="grid w-full grid-cols-2 gap-3 bg-gray-100 pb-5">
       {/* 클래스 등록 및 매장 운영 정보 등록 */}
       <div className="flex flex-col gap-3">
         <StoryManagement />

--- a/src/shared/components/layout/aside/aside.tsx
+++ b/src/shared/components/layout/aside/aside.tsx
@@ -1,4 +1,4 @@
-import { useState, type MouseEvent } from 'react';
+import { useState, useRef, useEffect, type MouseEvent } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { useSelector } from 'react-redux';
 import {
@@ -24,9 +24,29 @@ import DearObjectWhiteLogo from '../../../../assets/dear-objet-white-logo.svg';
 export const Aside = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const asideRef = useRef<HTMLElement>(null);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [activeMenu, setActiveMenu] = useState(location.pathname);
   const role = useSelector((state: RootState) => state.auth.user?.role);
   const { data: userMe } = useGetMeQuery();
+
+  const handleScroll = () => {
+    const el = asideRef.current;
+    if (!el) return;
+
+    el.classList.add('is-scrolling');
+
+    if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    scrollTimerRef.current = setTimeout(() => {
+      el.classList.remove('is-scrolling');
+    }, 500); // 스크롤 멈춘 뒤 500ms 후 사라짐
+  };
+
+  useEffect(() => {
+    return () => {
+      if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+    };
+  }, []);
 
   const handleClick = (path: string) => {
     setActiveMenu(path);
@@ -47,7 +67,11 @@ export const Aside = () => {
     };
 
   return (
-    <aside className="flex flex-col bg-black pb-[2.875rem] pl-[2.375rem] pr-[3.75rem] pt-[3.25rem] text-white">
+    <aside
+      ref={asideRef}
+      onScroll={handleScroll}
+      className="aside-scroll flex flex-col overflow-y-auto bg-black pb-[2.875rem] pl-[2.375rem] pr-[3.375rem] pt-[3.25rem] text-white"
+    >
       <section className="flex items-center gap-2 text-[1.1875rem]">
         <img
           src={DearObjectWhiteLogo}
@@ -410,7 +434,7 @@ export const Aside = () => {
       </section>
 
       <UserProfile
-        className="mt-auto"
+        className="mt-10"
         variant="aside"
         userName={userMe?.name ?? ''}
         userId={userMe?.email}

--- a/src/shared/components/layout/partner-layout.tsx
+++ b/src/shared/components/layout/partner-layout.tsx
@@ -5,13 +5,13 @@ import { PartnerHeader } from './partner-header';
 
 export const PartnerLayout = () => {
   return (
-    <div className="flex min-h-screen w-full">
+    <div className="flex h-screen w-full overflow-hidden">
       <Aside />
 
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col">
         <PartnerHeader />
 
-        <main className="flex-1 bg-gray-100">
+        <main className="flex-1 overflow-y-auto bg-gray-100">
           <div className="mx-auto h-full w-full max-w-[120rem] p-5 px-[3.625rem]">
             <Outlet />
           </div>

--- a/src/shared/components/layout/partner-layout.tsx
+++ b/src/shared/components/layout/partner-layout.tsx
@@ -11,8 +11,8 @@ export const PartnerLayout = () => {
       <div className="flex min-h-0 flex-1 flex-col">
         <PartnerHeader />
 
-        <main className="flex-1 overflow-hidden bg-gray-100">
-          <div className="mx-auto h-full w-full max-w-[120rem] p-5 px-[3.625rem]">
+        <main className="flex-1 overflow-y-auto bg-gray-100">
+          <div className="mx-auto h-full w-full max-w-[120rem] px-[3.625rem] py-5">
             <Outlet />
           </div>
         </main>

--- a/src/shared/components/layout/partner-layout.tsx
+++ b/src/shared/components/layout/partner-layout.tsx
@@ -11,7 +11,7 @@ export const PartnerLayout = () => {
       <div className="flex min-h-0 flex-1 flex-col">
         <PartnerHeader />
 
-        <main className="flex-1 overflow-y-auto bg-gray-100">
+        <main className="flex-1 overflow-hidden bg-gray-100">
           <div className="mx-auto h-full w-full max-w-[120rem] p-5 px-[3.625rem]">
             <Outlet />
           </div>

--- a/src/shared/styles/index.css
+++ b/src/shared/styles/index.css
@@ -137,4 +137,34 @@
   ::-webkit-scrollbar-track {
     background: transparent;
   }
+
+  /* Aside 스크롤바 - 평소엔 투명, 스크롤 중에만 표시 */
+  .aside-scroll::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  .aside-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .aside-scroll::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 9999px;
+    transition: background 0.8s ease;
+  }
+
+  .aside-scroll.is-scrolling::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.25);
+  }
+
+  /* Firefox */
+  .aside-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+    transition: scrollbar-color 0.8s ease;
+  }
+
+  .aside-scroll.is-scrolling {
+    scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+  }
 }


### PR DESCRIPTION
* PartnerLayout
  - 루트 컨테이너를 h-screen overflow-hidden으로 변경해 뷰포트 고정
  - 우측 컬럼에 min-h-0 추가로 flex child overflow 방지
  - main 영역 overflow-y-auto 적용으로 콘텐츠 영역 독립 스크롤 처리

* Aside
  - overflow-y-auto 적용으로 aside 독립 스크롤 처리
  - scroll 이벤트 + 타이머 기반 is-scrolling 클래스 토글 구현
  - 스크롤바가 스크롤 시 서서히 나타나고 멈추면 서서히 사라지도록 처리
  - transition을 기본 상태에 선언해 페이드 인/아웃 동작 보장

* ShopManagement
  - 페이지 루트의 overflow-y-auto 제거, main에서 스크롤 위임
  - 하단 여백 보장을 위한 pb-5 추가

* Post / MyPosts / MyFavorites
  - PostGrid, MyPostsGrid, MyFavoritesGrid의 overflow-y-auto 스크롤 컨테이너 제거
  - window 스크롤 단일화로 Footer까지 자연스럽게 이어지는 스크롤 흐름 구현