### PR TITLE
feat: map page 입점작가 tab api 연결 작업

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -21,6 +21,7 @@ import {
   mapStoryApi,
   favoriteApi,
   reviewApi,
+  mapArtistApi,
 } from '../features/map';
 import { chatApi } from '../features/chat/api/chat-api';
 import { myPageApi } from '../features/my-page/api/my-page-api';
@@ -54,6 +55,7 @@ export const store = configureStore({
     [mapStoryApi.reducerPath]: mapStoryApi.reducer,
     [favoriteApi.reducerPath]: favoriteApi.reducer,
     [reviewApi.reducerPath]: reviewApi.reducer,
+    [mapArtistApi.reducerPath]: mapArtistApi.reducer,
     [chatApi.reducerPath]: chatApi.reducer,
     [myPageApi.reducerPath]: myPageApi.reducer,
     [userMeApi.reducerPath]: userMeApi.reducer,
@@ -81,6 +83,7 @@ export const store = configureStore({
       .concat(mapStoryApi.middleware)
       .concat(favoriteApi.middleware)
       .concat(reviewApi.middleware)
+      .concat(mapArtistApi.middleware)
       .concat(chatApi.middleware)
       .concat(myPageApi.middleware)
       .concat(userMeApi.middleware)

--- a/src/features/map/api/map-artist-api.ts
+++ b/src/features/map/api/map-artist-api.ts
@@ -1,0 +1,21 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import { createBaseQuery } from '../../../shared/constants';
+
+import type { MapArtistListResponse } from '../types/map-artist-types';
+
+export const mapArtistApi = createApi({
+  reducerPath: 'mapArtistApi',
+  baseQuery: createBaseQuery(),
+  tagTypes: ['MapArtist'],
+  endpoints: (builder) => ({
+    getShopArtists: builder.query<MapArtistListResponse, number>({
+      query: (shopId) => ({ url: `/api/v1/shops/${shopId}/artists` }),
+      transformResponse: (response: { data: MapArtistListResponse }) =>
+        response.data,
+      providesTags: ['MapArtist'],
+    }),
+  }),
+});
+
+export const { useGetShopArtistsQuery } = mapArtistApi;

--- a/src/features/map/components/artist-tab.tsx
+++ b/src/features/map/components/artist-tab.tsx
@@ -1,59 +1,39 @@
-import { useInfiniteScroll } from '../hooks/use-infinite-scroll';
+import { useGetShopArtistsQuery } from '../api/map-artist-api';
+import type { ArtistTabProps } from '../types/map-artist-types';
 
-interface Artist {
-  artistId: number;
-  name: string;
-  profileImageUrl: string | null;
-}
+export const ArtistTab = ({ shopId }: ArtistTabProps) => {
+  const { data, isLoading } = useGetShopArtistsQuery(shopId);
 
-const fetchArtists = async (page: number) => {
-  await new Promise((resolve) => setTimeout(resolve, 500));
+  if (isLoading) {
+    return (
+      <p className="py-6 text-center text-sm text-theme-300">불러오는 중...</p>
+    );
+  }
 
-  const names = ['김댕댕', '러브미모어', '파워J', '솜다람', '별하', '모모'];
-  const items: Artist[] = Array.from({ length: 6 }, (_, i) => ({
-    artistId: (page - 1) * 6 + i + 1,
-    name: names[i % names.length],
-    profileImageUrl: null,
-  }));
-
-  return { items, hasMore: page < 5 };
-};
-
-export const ArtistTab = () => {
-  const { items, isLoading, hasMore, observerTargetRef } =
-    useInfiniteScroll<Artist>({
-      fetchData: fetchArtists,
-    });
+  if (!data?.items.length) {
+    return (
+      <p className="py-6 text-center text-xs text-theme-300">
+        입점 작가가 없습니다.
+      </p>
+    );
+  }
 
   return (
-    <div className="flex flex-col">
-      <div className="grid grid-cols-3 gap-6 p-4">
-        {items.map((artist) => (
-          <div
-            key={artist.artistId}
-            className="flex flex-col items-center gap-1"
-          >
-            {/* 프로필 사진 */}
-            <div className="h-28 w-28 overflow-hidden rounded-full bg-theme-200">
-              {artist.profileImageUrl && (
-                <img
-                  src={artist.profileImageUrl}
-                  alt={artist.name}
-                  className="h-full w-full object-cover"
-                />
-              )}
-            </div>
-            {/* 이름 */}
-            <p className="text-sm text-theme-900">{artist.name}</p>
+    <div className="grid grid-cols-3 gap-6 p-4">
+      {data.items.map((artist) => (
+        <div key={artist.artistId} className="flex flex-col items-center gap-1">
+          <div className="h-28 w-28 overflow-hidden rounded-full bg-theme-200">
+            {artist.artistImageUrl && (
+              <img
+                src={artist.artistImageUrl}
+                alt={artist.artistName}
+                className="h-full w-full object-cover"
+              />
+            )}
           </div>
-        ))}
-      </div>
-      <div ref={observerTargetRef} className="py-2 text-center">
-        {isLoading && <p className="text-sm text-theme-300">불러오는 중...</p>}
-        {!hasMore && (
-          <p className="text-sm text-theme-300">마지막 작가입니다.</p>
-        )}
-      </div>
+          <p className="text-sm text-theme-900">{artist.artistName}</p>
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/features/map/components/map-aside.tsx
+++ b/src/features/map/components/map-aside.tsx
@@ -252,7 +252,9 @@ export const MapAside = ({ shopDetail, shopId }: ShopPanelProps) => {
         {activeTab === '원데이클래스' && shopId && (
           <OneDayClassTab shopId={shopId} shopName={shopDetail.shopName} />
         )}
-        {activeTab === '입점작가' && <ArtistTab />}
+        {activeTab === '입점작가' && shopId !== null && (
+          <ArtistTab shopId={shopId} />
+        )}
         {activeTab === '리뷰' && shopId !== null && (
           <ReviewTab shopId={shopId} />
         )}

--- a/src/features/map/index.ts
+++ b/src/features/map/index.ts
@@ -9,3 +9,4 @@ export { oneDayClassApi } from './api/one-day-class-api';
 export { mapStoryApi } from './api/map-story-api';
 export { favoriteApi } from './api/favorite-api';
 export { reviewApi } from './api/review-api';
+export { mapArtistApi } from './api/map-artist-api';

--- a/src/features/map/types/map-artist-types.ts
+++ b/src/features/map/types/map-artist-types.ts
@@ -1,0 +1,13 @@
+export interface MapArtistItem {
+  artistId: number;
+  artistName: string;
+  artistImageUrl: string | null;
+}
+
+export interface MapArtistListResponse {
+  items: MapArtistItem[];
+}
+
+export interface ArtistTabProps {
+  shopId: number;
+}


### PR DESCRIPTION
* map-artist
  - `map-artist-types.ts` — MapArtistItem, MapArtistListResponse, ArtistTabProps 타입 정의
  - `map-artist-api.ts` — `GET /api/v1/shops/:shopId/artists` RTK Query 엔드포인트 추가
  - `ArtistTab` — mock 데이터 및 무한스크롤 제거, `useGetShopArtistsQuery` 로 교체
  - `MapAside` — ArtistTab에 shopId prop 전달