### PR TITLE
fix: 찜 토글 후 isFavorited 상태 동기화 버그 수정

### DIFF
--- a/src/features/map/components/map-aside.tsx
+++ b/src/features/map/components/map-aside.tsx
@@ -47,10 +47,10 @@ export const MapAside = ({ shopDetail, shopId }: ShopPanelProps) => {
     const next = !isFavorited;
     setIsFavorited(next);
     try {
-      if (isFavorited) {
-        await removeFavorite(shopId).unwrap();
-      } else {
+      if (next) {
         await addFavorite(shopId).unwrap();
+      } else {
+        await removeFavorite(shopId).unwrap();
       }
     } catch {
       setIsFavorited(!next);
@@ -68,9 +68,7 @@ export const MapAside = ({ shopDetail, shopId }: ShopPanelProps) => {
 
   useEffect(() => {
     setIsFavorited(shopDetail?.isFavorite ?? false);
-    // shopId 변경 시에만 초기화하는 것이 의도적 - isFavorite 값이 같아도 샵이 바뀌면 리셋되어야 함
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shopId]);
+  }, [shopId, shopDetail?.isFavorite]);
 
   useEffect(() => {
     setActiveTab('스토리');


### PR DESCRIPTION
찜 버튼 클릭 후 다른 소품샵들을 여러번 선택해서 map aside의 정보가 바뀌는 경우 찜 버튼이 제대로 동기화 되지 않는 문제점을 수정함. 